### PR TITLE
Set ingress class default to false

### DIFF
--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -56,7 +56,7 @@ To uninstall the chart:
 | `image.pullSecrets`          | An array of imagePullSecrets to be used when pulling the image.                                                       | `[]`                                  |
 | `ingressClass.name`          | The name of the ingress class to use.                                                                                 | `ngrok`                               |
 | `ingressClass.create`        | Whether to create the ingress class.                                                                                  | `true`                                |
-| `ingressClass.default`       | Whether to set the ingress class as default.                                                                          | `true`                                |
+| `ingressClass.default`       | Whether to set the ingress class as default.                                                                          | `false`                               |
 | `credentials.secret.name`    | The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.    | `""`                                  |
 | `credentials.apiKey`         | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well. | `""`                                  |
 | `credentials.authtoken`      | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.  | `""`                                  |

--- a/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -3,8 +3,6 @@ Should match snapshot:
     apiVersion: networking.k8s.io/v1
     kind: IngressClass
     metadata:
-      annotations:
-        ingressclass.kubernetes.io/is-default-class: "true"
       labels:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: RELEASE-NAME

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -46,7 +46,7 @@ image:
 ingressClass:
   name: ngrok
   create: true
-  default: true
+  default: false
 
 ## @param credentials.secret.name The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.
 ## @param credentials.apiKey Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well.

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -24,6 +24,13 @@ do
   echo "kubectl get ingress -n $i -o=json | jq '.metadata.finalizers = null' | kubectl apply -f -"
   kubectl get ingress -n $i -o=json | jq '.metadata.finalizers = null' | kubectl apply -f -
 done
+# Remove finalizers from domains in namespace
+kubectl get domains -A -o custom-columns=NAMESPACE:metadata.namespace,NAME:metadata.name --no-headers | \
+while read -r i
+do
+  echo "kubectl get domains -n $i -o=json | jq '.metadata.finalizers = null' | kubectl apply -f -"
+  kubectl get domains -n $i -o=json | jq '.metadata.finalizers = null' | kubectl apply -f -
+done
 
 kubectl delete namespace $namespace --ignore-not-found
 


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
Changes the default helm values for whether the ngrok ingress class should be the default from true to false. We should not assume we would be the default as it could cause problems if someone installs it in a cluster with another ingress controller.

## How
Change the value in the values.yaml file

## Breaking Changes
Technically yes, this is non-passive and reverses the behavior. If its installed in a cluster and its the only ingress class though, it will not pickup things by default anymore.

Our logic for how ingress classes are handled is here https://github.com/ngrok/kubernetes-ingress-controller/blob/main/internal/controllers/main.go#L29-L37 . With these helm defaults, you would install it in the cluster and would need to specify the ingress class on their ingress objects. Alternatively, if we set the default value for `ingressClass.create` to false, then if this is the only controller installed https://github.com/ngrok/kubernetes-ingress-controller/blob/main/internal/controllers/main.go#L30 would make it handle ingress objects by default. 

Our logic for ingress classes may need to change up a bit at some point, but I haven't found any specifications on how it behaves in each scenario. 
