### PR TITLE
Tcp edge fixes

### DIFF
--- a/internal/ngrokapi/clientset.go
+++ b/internal/ngrokapi/clientset.go
@@ -6,13 +6,15 @@ import (
 	https_edges "github.com/ngrok/ngrok-api-go/v5/edges/https"
 	https_edge_routes "github.com/ngrok/ngrok-api-go/v5/edges/https_routes"
 	tcp_edges "github.com/ngrok/ngrok-api-go/v5/edges/tcp"
+	"github.com/ngrok/ngrok-api-go/v5/reserved_addrs"
 	"github.com/ngrok/ngrok-api-go/v5/reserved_domains"
 )
 
-type CLientset interface {
+type Clientset interface {
 	Domains() *reserved_domains.Client
 	HTTPSEdges() *https_edges.Client
 	HTTPSEdgeRoutes() *https_edge_routes.Client
+	TCPAddresses() *reserved_addrs.Client
 	TCPEdges() *tcp_edges.Client
 	TunnelGroupBackends() *tunnel_group_backends.Client
 }
@@ -21,16 +23,19 @@ type DefaultClientset struct {
 	domainsClient             *reserved_domains.Client
 	httpsEdgesClient          *https_edges.Client
 	httpsEdgeRoutesClient     *https_edge_routes.Client
+	tcpAddrsClient            *reserved_addrs.Client
 	tcpEdgesClient            *tcp_edges.Client
 	tunnelGroupBackendsClient *tunnel_group_backends.Client
 }
 
+// NewClientSet creates a new ClientSet from an ngrok client config.
 func NewClientSet(config *ngrok.ClientConfig) *DefaultClientset {
 	return &DefaultClientset{
 		domainsClient:             reserved_domains.NewClient(config),
 		httpsEdgesClient:          https_edges.NewClient(config),
 		httpsEdgeRoutesClient:     https_edge_routes.NewClient(config),
 		tcpEdgesClient:            tcp_edges.NewClient(config),
+		tcpAddrsClient:            reserved_addrs.NewClient(config),
 		tunnelGroupBackendsClient: tunnel_group_backends.NewClient(config),
 	}
 }
@@ -45,6 +50,10 @@ func (c *DefaultClientset) HTTPSEdges() *https_edges.Client {
 
 func (c *DefaultClientset) HTTPSEdgeRoutes() *https_edge_routes.Client {
 	return c.httpsEdgeRoutesClient
+}
+
+func (c *DefaultClientset) TCPAddresses() *reserved_addrs.Client {
+	return c.tcpAddrsClient
 }
 
 func (c *DefaultClientset) TCPEdges() *tcp_edges.Client {

--- a/internal/ngrokapi/clientset_test.go
+++ b/internal/ngrokapi/clientset_test.go
@@ -1,0 +1,22 @@
+package ngrokapi
+
+import (
+	"testing"
+
+	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultClientsetImplementsInterface(t *testing.T) {
+	cs := &DefaultClientset{}
+	assert.Implements(t, (*Clientset)(nil), cs)
+}
+
+func ExampleClientset() {
+	// Create a ngrok client config
+	config := ngrok.NewClientConfig("YOUR_API_KEY")
+	// Create a clientset using the provided ngrok client configuration.
+	cs := NewClientSet(config)
+	// Use the clientset to access the various clients.
+	cs.Domains()
+}

--- a/main.go
+++ b/main.go
@@ -190,6 +190,7 @@ func runController(ctx context.Context, opts managerOpts) error {
 		Log:                      ctrl.Log.WithName("controllers").WithName("tcp-edge"),
 		Scheme:                   mgr.GetScheme(),
 		Recorder:                 mgr.GetEventRecorderFor("tcp-edge-controller"),
+		TCPAddrsClient:           ngrokClientset.TCPAddresses(),
 		TCPEdgeClient:            ngrokClientset.TCPEdges(),
 		TunnelGroupBackendClient: ngrokClientset.TunnelGroupBackends(),
 	}).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
## What

This fixes some issues in the TCPEdge Controller. Mainly it would not automatically provision a TCP address and attach it to the edge and you had to manually do this. Now it will reserve a TCP Address and attach it to the edge.

## How

Checks to see if an existing TCP Address with matching metadata already exists and if so, will use that. Otherwise, it will create a new one and attach it to the Edge

## Breaking Changes

No
