### PR TITLE
Add nested Clientsets for manipulating Route Modules

### DIFF
--- a/internal/ngrokapi/clientset.go
+++ b/internal/ngrokapi/clientset.go
@@ -14,6 +14,7 @@ import (
 
 type Clientset interface {
 	Domains() *reserved_domains.Client
+	EdgeModules() EdgeModulesClientset
 	HTTPSEdges() *https_edges.Client
 	HTTPSEdgeRoutes() *https_edge_routes.Client
 	IPPolicies() *ip_policies.Client
@@ -25,6 +26,7 @@ type Clientset interface {
 
 type DefaultClientset struct {
 	domainsClient             *reserved_domains.Client
+	edgeModulesClientset      *defaultEdgeModulesClientset
 	httpsEdgesClient          *https_edges.Client
 	httpsEdgeRoutesClient     *https_edge_routes.Client
 	ipPoliciesClient          *ip_policies.Client
@@ -38,6 +40,7 @@ type DefaultClientset struct {
 func NewClientSet(config *ngrok.ClientConfig) *DefaultClientset {
 	return &DefaultClientset{
 		domainsClient:             reserved_domains.NewClient(config),
+		edgeModulesClientset:      newEdgeModulesClientset(config),
 		httpsEdgesClient:          https_edges.NewClient(config),
 		httpsEdgeRoutesClient:     https_edge_routes.NewClient(config),
 		ipPoliciesClient:          ip_policies.NewClient(config),
@@ -50,6 +53,10 @@ func NewClientSet(config *ngrok.ClientConfig) *DefaultClientset {
 
 func (c *DefaultClientset) Domains() *reserved_domains.Client {
 	return c.domainsClient
+}
+
+func (c *DefaultClientset) EdgeModules() EdgeModulesClientset {
+	return c.edgeModulesClientset
 }
 
 func (c *DefaultClientset) HTTPSEdges() *https_edges.Client {

--- a/internal/ngrokapi/clientset_test.go
+++ b/internal/ngrokapi/clientset_test.go
@@ -17,6 +17,10 @@ func ExampleClientset() {
 	config := ngrok.NewClientConfig("YOUR_API_KEY")
 	// Create a clientset using the provided ngrok client configuration.
 	cs := NewClientSet(config)
-	// Use the clientset to access the various clients.
+	// Access a client for the domains API.
 	cs.Domains()
+	// Access a client for TCP Edge modules
+	cs.EdgeModules().TCP()
+	// Access a client for HTTPS Edge Route Modules
+	cs.EdgeModules().HTTPS().Routes().Compression()
 }

--- a/internal/ngrokapi/edge_modules_clientset.go
+++ b/internal/ngrokapi/edge_modules_clientset.go
@@ -1,0 +1,35 @@
+package ngrokapi
+
+import "github.com/ngrok/ngrok-api-go/v5"
+
+type EdgeModulesClientset interface {
+	TCP() TCPEdgeModulesClientset
+	HTTPS() HTTPSEdgeModulesClientset
+	TLS() TLSEdgeModulesClientset
+}
+
+type defaultEdgeModulesClientset struct {
+	tcp   *defaultTCPEdgeModulesClientset
+	https *defaultHTTPSEdgeModulesClientset
+	tls   *defaultTLSEdgeModulesClientset
+}
+
+func newEdgeModulesClientset(config *ngrok.ClientConfig) *defaultEdgeModulesClientset {
+	return &defaultEdgeModulesClientset{
+		tcp:   newTCPEdgeModulesClientset(config),
+		https: newHTTPSEdgeModulesClientset(config),
+		tls:   newTLSEdgeModulesClientset(config),
+	}
+}
+
+func (c *defaultEdgeModulesClientset) TCP() TCPEdgeModulesClientset {
+	return c.tcp
+}
+
+func (c *defaultEdgeModulesClientset) HTTPS() HTTPSEdgeModulesClientset {
+	return c.https
+}
+
+func (c *defaultEdgeModulesClientset) TLS() TLSEdgeModulesClientset {
+	return c.tls
+}

--- a/internal/ngrokapi/edge_modules_https.go
+++ b/internal/ngrokapi/edge_modules_https.go
@@ -1,0 +1,138 @@
+package ngrokapi
+
+import (
+	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_mutual_tls"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_route_backend"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_route_circuit_breaker"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_route_compression"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_route_ip_restriction"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_route_oauth"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_route_oidc"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_route_request_headers"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_route_response_headers"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_route_saml"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_route_webhook_verification"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_route_websocket_tcp_converter"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/https_edge_tls_termination"
+)
+
+type HTTPSEdgeModulesClientset interface {
+	MutualTLS() *https_edge_mutual_tls.Client
+	Routes() HTTPSEdgeRouteModulesClientset
+	TLSTermination() *https_edge_tls_termination.Client
+}
+
+type defaultHTTPSEdgeModulesClientset struct {
+	mutualTLS      *https_edge_mutual_tls.Client
+	routes         *defaultHTTPSEdgeRouteModulesClientset
+	tlsTermination *https_edge_tls_termination.Client
+}
+
+func newHTTPSEdgeModulesClientset(config *ngrok.ClientConfig) *defaultHTTPSEdgeModulesClientset {
+	return &defaultHTTPSEdgeModulesClientset{
+		mutualTLS:      https_edge_mutual_tls.NewClient(config),
+		routes:         newHTTPSEdgeRouteModulesClient(config),
+		tlsTermination: https_edge_tls_termination.NewClient(config),
+	}
+}
+
+func (c *defaultHTTPSEdgeModulesClientset) MutualTLS() *https_edge_mutual_tls.Client {
+	return c.mutualTLS
+}
+
+func (c *defaultHTTPSEdgeModulesClientset) Routes() HTTPSEdgeRouteModulesClientset {
+	return c.routes
+}
+
+func (c *defaultHTTPSEdgeModulesClientset) TLSTermination() *https_edge_tls_termination.Client {
+	return c.tlsTermination
+}
+
+type HTTPSEdgeRouteModulesClientset interface {
+	Backend() *https_edge_route_backend.Client
+	CircuitBreaker() *https_edge_route_circuit_breaker.Client
+	Compression() *https_edge_route_compression.Client
+	IPRestriction() *https_edge_route_ip_restriction.Client
+	OAuth() *https_edge_route_oauth.Client
+	OIDC() *https_edge_route_oidc.Client
+	RequestHeaders() *https_edge_route_request_headers.Client
+	ResponseHeaders() *https_edge_route_response_headers.Client
+	SAML() *https_edge_route_saml.Client
+	WebhookVerification() *https_edge_route_webhook_verification.Client
+	WebsocketTCPConverter() *https_edge_route_websocket_tcp_converter.Client
+}
+
+type defaultHTTPSEdgeRouteModulesClientset struct {
+	backend               *https_edge_route_backend.Client
+	circuitBreaker        *https_edge_route_circuit_breaker.Client
+	compression           *https_edge_route_compression.Client
+	ipRestriction         *https_edge_route_ip_restriction.Client
+	oauth                 *https_edge_route_oauth.Client
+	oidc                  *https_edge_route_oidc.Client
+	requestHeaders        *https_edge_route_request_headers.Client
+	responseHeaders       *https_edge_route_response_headers.Client
+	saml                  *https_edge_route_saml.Client
+	webhookVerification   *https_edge_route_webhook_verification.Client
+	websocketTCPConverter *https_edge_route_websocket_tcp_converter.Client
+}
+
+func newHTTPSEdgeRouteModulesClient(config *ngrok.ClientConfig) *defaultHTTPSEdgeRouteModulesClientset {
+	return &defaultHTTPSEdgeRouteModulesClientset{
+		backend:               https_edge_route_backend.NewClient(config),
+		circuitBreaker:        https_edge_route_circuit_breaker.NewClient(config),
+		compression:           https_edge_route_compression.NewClient(config),
+		ipRestriction:         https_edge_route_ip_restriction.NewClient(config),
+		oauth:                 https_edge_route_oauth.NewClient(config),
+		oidc:                  https_edge_route_oidc.NewClient(config),
+		requestHeaders:        https_edge_route_request_headers.NewClient(config),
+		responseHeaders:       https_edge_route_response_headers.NewClient(config),
+		saml:                  https_edge_route_saml.NewClient(config),
+		webhookVerification:   https_edge_route_webhook_verification.NewClient(config),
+		websocketTCPConverter: https_edge_route_websocket_tcp_converter.NewClient(config),
+	}
+}
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) Backend() *https_edge_route_backend.Client {
+	return c.backend
+}
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) CircuitBreaker() *https_edge_route_circuit_breaker.Client {
+	return c.circuitBreaker
+}
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) Compression() *https_edge_route_compression.Client {
+	return c.compression
+}
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) IPRestriction() *https_edge_route_ip_restriction.Client {
+	return c.ipRestriction
+}
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) OAuth() *https_edge_route_oauth.Client {
+	return c.oauth
+}
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) OIDC() *https_edge_route_oidc.Client {
+	return c.oidc
+}
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) RequestHeaders() *https_edge_route_request_headers.Client {
+	return c.requestHeaders
+}
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) ResponseHeaders() *https_edge_route_response_headers.Client {
+	return c.responseHeaders
+}
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) SAML() *https_edge_route_saml.Client {
+	return c.saml
+}
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) WebhookVerification() *https_edge_route_webhook_verification.Client {
+	return c.webhookVerification
+}
+
+func (c *defaultHTTPSEdgeRouteModulesClientset) WebsocketTCPConverter() *https_edge_route_websocket_tcp_converter.Client {
+	return c.websocketTCPConverter
+}

--- a/internal/ngrokapi/edge_modules_tcp_clientset.go
+++ b/internal/ngrokapi/edge_modules_tcp_clientset.go
@@ -1,0 +1,32 @@
+package ngrokapi
+
+import (
+	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tcp_edge_backend"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tcp_edge_ip_restriction"
+)
+
+type TCPEdgeModulesClientset interface {
+	Backend() *tcp_edge_backend.Client
+	IPRestriction() *tcp_edge_ip_restriction.Client
+}
+
+type defaultTCPEdgeModulesClientset struct {
+	backend       *tcp_edge_backend.Client
+	ipRestriction *tcp_edge_ip_restriction.Client
+}
+
+func newTCPEdgeModulesClientset(config *ngrok.ClientConfig) *defaultTCPEdgeModulesClientset {
+	return &defaultTCPEdgeModulesClientset{
+		backend:       tcp_edge_backend.NewClient(config),
+		ipRestriction: tcp_edge_ip_restriction.NewClient(config),
+	}
+}
+
+func (c *defaultTCPEdgeModulesClientset) Backend() *tcp_edge_backend.Client {
+	return c.backend
+}
+
+func (c *defaultTCPEdgeModulesClientset) IPRestriction() *tcp_edge_ip_restriction.Client {
+	return c.ipRestriction
+}

--- a/internal/ngrokapi/edge_modules_tls_clientset.go
+++ b/internal/ngrokapi/edge_modules_tls_clientset.go
@@ -1,0 +1,48 @@
+package ngrokapi
+
+import (
+	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tls_edge_backend"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tls_edge_ip_restriction"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tls_edge_mutual_tls"
+	"github.com/ngrok/ngrok-api-go/v5/edge_modules/tls_edge_tls_termination"
+)
+
+type TLSEdgeModulesClientset interface {
+	Backend() *tls_edge_backend.Client
+	IPRestriction() *tls_edge_ip_restriction.Client
+	MutualTLS() *tls_edge_mutual_tls.Client
+	TLSTermination() *tls_edge_tls_termination.Client
+}
+
+type defaultTLSEdgeModulesClientset struct {
+	backend        *tls_edge_backend.Client
+	ipRestriction  *tls_edge_ip_restriction.Client
+	mutualTLS      *tls_edge_mutual_tls.Client
+	tlsTermination *tls_edge_tls_termination.Client
+}
+
+func newTLSEdgeModulesClientset(config *ngrok.ClientConfig) *defaultTLSEdgeModulesClientset {
+	return &defaultTLSEdgeModulesClientset{
+		backend:        tls_edge_backend.NewClient(config),
+		ipRestriction:  tls_edge_ip_restriction.NewClient(config),
+		mutualTLS:      tls_edge_mutual_tls.NewClient(config),
+		tlsTermination: tls_edge_tls_termination.NewClient(config),
+	}
+}
+
+func (c *defaultTLSEdgeModulesClientset) Backend() *tls_edge_backend.Client {
+	return c.backend
+}
+
+func (c *defaultTLSEdgeModulesClientset) IPRestriction() *tls_edge_ip_restriction.Client {
+	return c.ipRestriction
+}
+
+func (c *defaultTLSEdgeModulesClientset) MutualTLS() *tls_edge_mutual_tls.Client {
+	return c.mutualTLS
+}
+
+func (c *defaultTLSEdgeModulesClientset) TLSTermination() *tls_edge_tls_termination.Client {
+	return c.tlsTermination
+}

--- a/main.go
+++ b/main.go
@@ -196,13 +196,11 @@ func runController(ctx context.Context, opts managerOpts) error {
 		os.Exit(1)
 	}
 	if err = (&controllers.HTTPSEdgeReconciler{
-		Client:                   mgr.GetClient(),
-		Log:                      ctrl.Log.WithName("controllers").WithName("https-edge"),
-		Scheme:                   mgr.GetScheme(),
-		Recorder:                 mgr.GetEventRecorderFor("https-edge-controller"),
-		HTTPSEdgeClient:          ngrokClientset.HTTPSEdges(),
-		HTTPSEdgeRoutesClient:    ngrokClientset.HTTPSEdgeRoutes(),
-		TunnelGroupBackendClient: ngrokClientset.TunnelGroupBackends(),
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("https-edge"),
+		Scheme:         mgr.GetScheme(),
+		Recorder:       mgr.GetEventRecorderFor("https-edge-controller"),
+		NgrokClientset: ngrokClientset,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HTTPSEdge")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -186,13 +186,11 @@ func runController(ctx context.Context, opts managerOpts) error {
 		os.Exit(1)
 	}
 	if err = (&controllers.TCPEdgeReconciler{
-		Client:                   mgr.GetClient(),
-		Log:                      ctrl.Log.WithName("controllers").WithName("tcp-edge"),
-		Scheme:                   mgr.GetScheme(),
-		Recorder:                 mgr.GetEventRecorderFor("tcp-edge-controller"),
-		TCPAddrsClient:           ngrokClientset.TCPAddresses(),
-		TCPEdgeClient:            ngrokClientset.TCPEdges(),
-		TunnelGroupBackendClient: ngrokClientset.TunnelGroupBackends(),
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("tcp-edge"),
+		Scheme:         mgr.GetScheme(),
+		Recorder:       mgr.GetEventRecorderFor("tcp-edge-controller"),
+		NgrokClientset: ngrokClientset,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TCPEdge")
 		os.Exit(1)


### PR DESCRIPTION
## What

The HTTPSEdgeRoute update API does not support fully removing route modules. When we reconcile HTTPSEdgeRoutes, if a route module is removed from the spec, we need to delete it. The only way to do that is through the HTTPSEdgeRouteModules API, so we will need clients for that. This will allow us to pass the `ngrokapi.Clientset` into various controllers that require complex logic that spans many different API clients from `ngrok-api-go`. This should clean up dependency injection as we start adding more route modules.

## How

Add nested clientsets to the ngrok API clientset. We will start consuming these in subsequent PRs.

## Breaking Changes

No