### PR TITLE
Alex/cache stores

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,8 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onsi/ginkgo/v2 v2.6.1 // indirect
+	github.com/onsi/ginkgo/v2 v2.7.0 // indirect
+	github.com/onsi/gomega v1.26.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,12 @@ github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.6.1 h1:1xQPCjcqYw/J5LchOcp4/2q/jzJFjiAOc25chhnDw+Q=
 github.com/onsi/ginkgo/v2 v2.6.1/go.mod h1:yjiuMwPokqY1XauOgju45q3sJt6VzQ/Fict1LFVcsAo=
+github.com/onsi/ginkgo/v2 v2.7.0 h1:/XxtEV3I3Eif/HobnVx9YmJgk8ENdRsuUmM+fLCFNow=
+github.com/onsi/ginkgo/v2 v2.7.0/go.mod h1:yjiuMwPokqY1XauOgju45q3sJt6VzQ/Fict1LFVcsAo=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.24.2 h1:J/tulyYK6JwBldPViHJReihxxZ+22FHs0piGjQAvoUE=
+github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
+github.com/onsi/gomega v1.26.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
 github.com/paulmach/orb v0.1.3/go.mod h1:VFlX/8C+IQ1p6FTRRKzKoOPJnvEtA5G0Veuqwbu//Vk=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,5 +1,12 @@
 package errors
 
+import (
+	"fmt"
+	"strings"
+
+	netv1 "k8s.io/api/networking/v1"
+)
+
 // Not all domains are reconciled yet and have a domain in their status
 type NotAllDomainsReadyYetError struct{}
 
@@ -16,5 +23,97 @@ func NewNotAllDomainsReadyYetError() error {
 // IsNotAllDomainsReadyYet returns true if the error is a NotAllDomainsReadyYetError
 func IsNotAllDomainsReadyYet(err error) bool {
 	_, ok := err.(*NotAllDomainsReadyYetError)
+	return ok
+}
+
+// ErrNotFoundInStore is meant to be used when an object is not found in the store so
+// that the caller can decide what to do with it.
+type ErrNotFoundInStore struct {
+	message string
+}
+
+// NewErrorNotFound returns a new ErrNotFoundInStore
+func NewErrorNotFound(message string) ErrNotFoundInStore {
+	return ErrNotFoundInStore{message: message}
+}
+
+// Error: Stringer: returns the error message
+func (e ErrNotFoundInStore) Error() string {
+	return e.message
+}
+
+// IsErrorNotFound: Reflect: returns true if the error is a ErrNotFoundInStore
+func IsErrorNotFound(err error) bool {
+	_, ok := err.(ErrNotFoundInStore)
+	return ok
+}
+
+// ErrInvalidIngressClass is meant to be used when an ingress object has an invalid ingress class
+type ErrDifferentIngressClass struct {
+	message string
+}
+
+// NewErrDifferentIngressClass returns a new ErrDifferentIngressClass
+func NewErrDifferentIngressClass(ourIngressClasses []*netv1.IngressClass, foundIngressClass *string) ErrDifferentIngressClass {
+	msg := []string{"The controller will not reconcile this ingress object due to the ingress class mismatching."}
+	if foundIngressClass == nil {
+		msg = append(msg, "The ingress object does not have an ingress class set.")
+	} else {
+		msg = append(msg, fmt.Sprintf("The ingress object has an ingress class set to %s.", *foundIngressClass))
+	}
+	for _, ingressClass := range ourIngressClasses {
+		if ingressClass.Annotations["ingressclass.kubernetes.io/is-default-class"] == "true" {
+			msg = append(msg, fmt.Sprintf("This controller is the default ingress controller ingress class %s.", ingressClass.Name))
+		}
+		msg = append(msg, fmt.Sprintf("This controller is watching for the class %s", ingressClass.Name))
+	}
+	if len(ourIngressClasses) == 0 {
+		msg = append(msg, "There are no ngrok ingress classes registered in the cluster.")
+	}
+	return ErrDifferentIngressClass{message: strings.Join(msg, "\n")}
+}
+
+// Error: Stringer: returns the error message
+func (e ErrDifferentIngressClass) Error() string {
+	if e.message == "" {
+		return "different ingress class"
+	}
+	return e.message
+}
+
+// IsErrDifferentIngressClass: Reflect: returns true if the error is a ErrDifferentIngressClass
+func IsErrDifferentIngressClass(err error) bool {
+	_, ok := err.(ErrDifferentIngressClass)
+	return ok
+}
+
+// ErrInvalidIngressSpec is meant to be used when an ingress object has an invalid spec
+type ErrInvalidIngressSpec struct {
+	errors []string
+}
+
+// NewErrInvalidIngressSpec returns a new ErrInvalidIngressSpec
+func NewErrInvalidIngressSpec() ErrInvalidIngressSpec {
+	return ErrInvalidIngressSpec{}
+}
+
+// AddError adds an error to the list of errors
+func (e ErrInvalidIngressSpec) AddError(err string) {
+	e.errors = append(e.errors, err)
+}
+
+// HasErrors returns true if there are errors
+func (e ErrInvalidIngressSpec) HasErrors() bool {
+	return len(e.errors) > 0
+}
+
+// Error: Stringer: returns the error message
+func (e ErrInvalidIngressSpec) Error() string {
+	return fmt.Sprintf("invalid ingress spec: %s", e.errors)
+}
+
+// IsErrInvalidIngressSpec: Reflect: returns true if the error is a ErrInvalidIngressSpec
+func IsErrInvalidIngressSpec(err error) bool {
+	_, ok := err.(ErrInvalidIngressSpec)
 	return ok
 }

--- a/internal/store/cachestores.go
+++ b/internal/store/cachestores.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/go-logr/logr"
+	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/v1alpha1"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+// CacheStores stores cache.Store for all Kinds of k8s objects that
+// the Ingress Controller reads.
+type CacheStores struct {
+	// Core Kubernetes Stores
+	IngressV1      cache.Store
+	IngressClassV1 cache.Store
+
+	// Ngrok Stores
+	DomainV1    cache.Store
+	TunnelV1    cache.Store
+	HTTPSEdgeV1 cache.Store
+
+	log logr.Logger
+	l   *sync.RWMutex
+}
+
+// NewCacheStores is a convenience function for CacheStores to initialize all attributes with new cache stores.
+func NewCacheStores(logger logr.Logger) CacheStores {
+	return CacheStores{
+		IngressV1:      cache.NewStore(keyFunc),
+		IngressClassV1: cache.NewStore(clusterResourceKeyFunc),
+		DomainV1:       cache.NewStore(keyFunc),
+		TunnelV1:       cache.NewStore(keyFunc),
+		HTTPSEdgeV1:    cache.NewStore(keyFunc),
+		l:              &sync.RWMutex{},
+		log:            logger,
+	}
+}
+
+func keyFunc(obj interface{}) (string, error) {
+	v := reflect.Indirect(reflect.ValueOf(obj))
+	name := v.FieldByName("Name")
+	namespace := v.FieldByName("Namespace")
+	return namespace.String() + "/" + name.String(), nil
+}
+
+func clusterResourceKeyFunc(obj interface{}) (string, error) {
+	v := reflect.Indirect(reflect.ValueOf(obj))
+	return v.FieldByName("Name").String(), nil
+}
+
+// Get checks whether or not there's already some version of the provided object present in the cache.
+// The CacheStore must be initialized (see NewCacheStores()) or this will panic.
+func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err error) {
+	c.l.RLock()
+	defer c.l.RUnlock()
+
+	switch obj := obj.(type) {
+	// ----------------------------------------------------------------------------
+	// Kubernetes Core API Support
+	// ----------------------------------------------------------------------------
+	case *netv1.Ingress:
+		return c.IngressV1.Get(obj)
+	case *netv1.IngressClass:
+		return c.IngressClassV1.Get(obj)
+		// ----------------------------------------------------------------------------
+	// Ngrok API Support
+	// ----------------------------------------------------------------------------
+	case *ingressv1alpha1.Domain:
+		return c.DomainV1.Get(obj)
+	case *ingressv1alpha1.Tunnel:
+		return c.TunnelV1.Get(obj)
+	case *ingressv1alpha1.HTTPSEdge:
+		return c.HTTPSEdgeV1.Get(obj)
+	default:
+		return nil, false, fmt.Errorf("unsupported object type: %T", obj)
+	}
+}
+
+// Add stores a provided runtime.Object into the CacheStore if it's of a supported type.
+// The CacheStore must be initialized (see NewCacheStores()) or this will panic.
+func (c CacheStores) Add(obj runtime.Object) error {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	switch obj := obj.(type) {
+	// ----------------------------------------------------------------------------
+	// Kubernetes Core API Support
+	// ----------------------------------------------------------------------------
+	case *netv1.Ingress:
+		return c.IngressV1.Add(obj)
+
+	case *netv1.IngressClass:
+		return c.IngressClassV1.Add(obj)
+		// ----------------------------------------------------------------------------
+	// Ngrok API Support
+	// ----------------------------------------------------------------------------
+	case *ingressv1alpha1.Domain:
+		return c.DomainV1.Add(obj)
+	case *ingressv1alpha1.Tunnel:
+		return c.TunnelV1.Add(obj)
+	case *ingressv1alpha1.HTTPSEdge:
+		return c.HTTPSEdgeV1.Add(obj)
+
+	default:
+		return fmt.Errorf("unsupported object type: %T", obj)
+	}
+}
+
+// Delete removes a provided runtime.Object from the CacheStore if it's of a supported type.
+// The CacheStore must be initialized (see NewCacheStores()) or this will panic.
+func (c CacheStores) Delete(obj runtime.Object) error {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	switch obj := obj.(type) {
+	// ----------------------------------------------------------------------------
+	// Kubernetes Core API Support
+	// ----------------------------------------------------------------------------
+	case *netv1.Ingress:
+		return c.IngressV1.Delete(obj)
+	case *netv1.IngressClass:
+		return c.IngressClassV1.Delete(obj)
+		// ----------------------------------------------------------------------------
+	// Ngrok API Support
+	// ----------------------------------------------------------------------------
+	case *ingressv1alpha1.Domain:
+		return c.DomainV1.Delete(obj)
+	case *ingressv1alpha1.Tunnel:
+		return c.TunnelV1.Delete(obj)
+	case *ingressv1alpha1.HTTPSEdge:
+		return c.HTTPSEdgeV1.Delete(obj)
+	default:
+		return fmt.Errorf("unsupported object type: %T", obj)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -107,8 +107,7 @@ func (s Store) GetIngressClassV1(name string) (*netv1.IngressClass, error) {
 
 // GetIngressV1 returns the 'name' Ingress resource.
 func (s Store) GetIngressV1(name, namespcae string) (*netv1.Ingress, error) {
-	// TODO:(initial-store) key forming should be in its own function
-	p, exists, err := s.stores.IngressV1.GetByKey(fmt.Sprintf("%v/%v", namespcae, name))
+	p, exists, err := s.stores.IngressV1.GetByKey(getKey(name, namespcae))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/v1alpha1"
+	"github.com/ngrok/kubernetes-ingress-controller/internal/errors"
+
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/go-logr/logr"
+)
+
+// Storer is the interface that wraps the required methods to gather information
+// about ingresses, services, secrets and ingress annotations.
+// It exposes methods to list both all and filtered resources
+type Storer interface {
+	Get(obj runtime.Object) (item interface{}, exists bool, err error)
+	Add(runtime.Object) error
+	Update(runtime.Object) error
+	Delete(runtime.Object) error
+
+	GetIngressClassV1(name string) (*netv1.IngressClass, error)
+	GetIngressV1(name, namespace string) (*netv1.Ingress, error)
+	GetNgrokIngressV1(name, namespace string) (*netv1.Ingress, error)
+
+	ListIngressClassesV1() []*netv1.IngressClass
+	ListNgrokIngressClassesV1() []*netv1.IngressClass
+
+	ListIngressesV1() []*netv1.Ingress
+	ListNgrokIngressesV1() []*netv1.Ingress
+
+	ListDomainsV1() []*ingressv1alpha1.Domain
+	ListTunnelsV1() []*ingressv1alpha1.Tunnel
+	ListHTTPSEdgesV1() []*ingressv1alpha1.HTTPSEdge
+}
+
+// Store implements Storer and can be used to list Ingress, Services
+// and other resources from k8s APIserver. The backing stores should
+// be synced and updated by the caller.
+// It is ingressClass filter aware.
+type Store struct {
+	stores         CacheStores
+	controllerName string
+	log            logr.Logger
+}
+
+var _ Storer = Store{}
+
+// New creates a new object store to be used in the ingress controller.
+func New(cs CacheStores, controllerName string, logger logr.Logger) Storer {
+	return Store{
+		stores:         cs,
+		controllerName: controllerName,
+		log:            logger,
+	}
+}
+
+// Get proxies the call to the underlying store.
+func (s Store) Get(obj runtime.Object) (interface{}, bool, error) {
+	return s.stores.Get(obj)
+}
+
+// Add proxies the call to the underlying store.
+func (s Store) Add(obj runtime.Object) error {
+	return s.stores.Add(obj.DeepCopyObject())
+}
+
+// Update proxies the call to the underlying store.
+// An add for an object with the same key thats already present is just an update
+func (s Store) Update(obj runtime.Object) error {
+	return s.stores.Add(obj.DeepCopyObject())
+}
+
+// Delete proxies the call to the underlying store.
+func (s Store) Delete(obj runtime.Object) error {
+	return s.stores.Delete(obj)
+}
+
+// GetIngressClassV1 returns the 'name' IngressClass resource.
+func (s Store) GetIngressClassV1(name string) (*netv1.IngressClass, error) {
+	p, exists, err := s.stores.IngressClassV1.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewErrorNotFound(fmt.Sprintf("IngressClass %v not found", name))
+	}
+	return p.(*netv1.IngressClass), nil
+}
+
+// GetIngressV1 returns the 'name' Ingress resource.
+func (s Store) GetIngressV1(name, namespcae string) (*netv1.Ingress, error) {
+	// TODO:(initial-store) key forming should be in its own function
+	p, exists, err := s.stores.IngressV1.GetByKey(fmt.Sprintf("%v/%v", namespcae, name))
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewErrorNotFound(fmt.Sprintf("Ingress %v not found", name))
+	}
+	return p.(*netv1.Ingress), nil
+}
+
+// GetNgrokIngressV1 looks up the Ingress resource by name and namespace and returns it if it's found
+func (s Store) GetNgrokIngressV1(name, namespace string) (*netv1.Ingress, error) {
+	ing, err := s.GetIngressV1(name, namespace)
+	if err != nil {
+		return nil, err
+	}
+	ok, err := s.shouldHandleIngress(ing)
+	if !ok || err != nil {
+		return nil, err
+	}
+
+	return ing, nil
+}
+
+// ListIngressClassesV1 returns the list of Ingresses in the Ingress v1 store.
+func (s Store) ListIngressClassesV1() []*netv1.IngressClass {
+	// filter ingress rules
+	var classes []*netv1.IngressClass
+	for _, item := range s.stores.IngressClassV1.List() {
+		class, ok := item.(*netv1.IngressClass)
+		if !ok {
+			s.log.Info("listIngressClassesV1: dropping object of unexpected type: %#v", item)
+			continue
+		}
+		classes = append(classes, class)
+	}
+
+	sort.SliceStable(classes, func(i, j int) bool {
+		return strings.Compare(classes[i].Name, classes[j].Name) < 0
+	})
+
+	return classes
+}
+
+// ListNgrokIngressClassesV1 returns the list of Ingresses in the Ingress v1 store filtered
+// by ones that match the controllerName
+func (s Store) ListNgrokIngressClassesV1() []*netv1.IngressClass {
+	filteredClasses := []*netv1.IngressClass{}
+	classes := s.ListIngressClassesV1()
+	for _, class := range classes {
+		if class.Spec.Controller == s.controllerName {
+			filteredClasses = append(filteredClasses, class)
+		}
+	}
+
+	return filteredClasses
+}
+
+// ListIngressesV1 returns the list of Ingresses in the Ingress v1 store.
+func (s Store) ListIngressesV1() []*netv1.Ingress {
+	// filter ingress rules
+	var ingresses []*netv1.Ingress
+
+	for _, item := range s.stores.IngressV1.List() {
+		ing, ok := item.(*netv1.Ingress)
+		if !ok {
+			e := fmt.Sprintf("listIngressesV1: dropping object of unexpected type: %#v", item)
+			s.log.Error(fmt.Errorf(e), e)
+			continue
+		}
+		ingresses = append(ingresses, ing)
+	}
+
+	sort.SliceStable(ingresses, func(i, j int) bool {
+		return strings.Compare(fmt.Sprintf("%s/%s", ingresses[i].Namespace, ingresses[i].Name),
+			fmt.Sprintf("%s/%s", ingresses[j].Namespace, ingresses[j].Name)) < 0
+	})
+
+	return ingresses
+}
+
+func (s Store) ListNgrokIngressesV1() []*netv1.Ingress {
+	ings := s.ListIngressesV1()
+
+	var ingresses []*netv1.Ingress
+	for _, ing := range ings {
+		ok, err := s.shouldHandleIngress(ing)
+		if ok && err == nil {
+			ingresses = append(ingresses, ing)
+		}
+	}
+	return ingresses
+}
+
+// ListDomainsV1 returns the list of Domains in the Domain v1 store.
+func (s Store) ListDomainsV1() []*ingressv1alpha1.Domain {
+	// filter ingress rules
+	var domains []*ingressv1alpha1.Domain
+	for _, item := range s.stores.DomainV1.List() {
+		domain, ok := item.(*ingressv1alpha1.Domain)
+		if !ok {
+			s.log.Info("listDomainsV1: dropping object of unexpected type: %#v", item)
+			continue
+		}
+		domains = append(domains, domain)
+	}
+
+	sort.SliceStable(domains, func(i, j int) bool {
+		return strings.Compare(fmt.Sprintf("%s/%s", domains[i].Namespace, domains[i].Name),
+			fmt.Sprintf("%s/%s", domains[j].Namespace, domains[j].Name)) < 0
+	})
+
+	return domains
+}
+
+// ListTunnelsV1 returns the list of Tunnels in the Tunnel v1 store.
+func (s Store) ListTunnelsV1() []*ingressv1alpha1.Tunnel {
+	var tunnels []*ingressv1alpha1.Tunnel
+	for _, item := range s.stores.TunnelV1.List() {
+		tunnel, ok := item.(*ingressv1alpha1.Tunnel)
+		if !ok {
+			s.log.Info("listTunnelsV1: dropping object of unexpected type: %#v", item)
+			continue
+		}
+		tunnels = append(tunnels, tunnel)
+	}
+
+	sort.SliceStable(tunnels, func(i, j int) bool {
+		return strings.Compare(fmt.Sprintf("%s/%s", tunnels[i].Namespace, tunnels[i].Name),
+			fmt.Sprintf("%s/%s", tunnels[j].Namespace, tunnels[j].Name)) < 0
+	})
+
+	return tunnels
+}
+
+// ListHTTPSEdgesV1 returns the list of HTTPSEdges in the HTTPSEdge v1 store.
+func (s Store) ListHTTPSEdgesV1() []*ingressv1alpha1.HTTPSEdge {
+	var edges []*ingressv1alpha1.HTTPSEdge
+	for _, item := range s.stores.HTTPSEdgeV1.List() {
+		edge, ok := item.(*ingressv1alpha1.HTTPSEdge)
+		if !ok {
+			s.log.Info("listHTTPSEdgesV1: dropping object of unexpected type: %#v", item)
+			continue
+		}
+		edges = append(edges, edge)
+	}
+
+	sort.SliceStable(edges, func(i, j int) bool {
+		return strings.Compare(fmt.Sprintf("%s/%s", edges[i].Namespace, edges[i].Name),
+			fmt.Sprintf("%s/%s", edges[j].Namespace, edges[j].Name)) < 0
+	})
+
+	return edges
+}
+
+func (s Store) shouldHandleIngress(ing *netv1.Ingress) (bool, error) {
+	ok, err := s.shouldHandleIngressIsValid(ing)
+	if err != nil {
+		return ok, err
+	}
+	return s.shouldHandleIngressCheckClass(ing)
+}
+
+// shouldHandleIngressCheckClass checks if the ingress should be handled by the controller based on the ingress class
+func (s Store) shouldHandleIngressCheckClass(ing *netv1.Ingress) (bool, error) {
+	ngrokClasses := s.ListNgrokIngressClassesV1()
+	if ing.Spec.IngressClassName != nil {
+		for _, class := range ngrokClasses {
+			if *ing.Spec.IngressClassName == class.Name {
+				return true, nil
+			}
+		}
+	} else {
+		for _, class := range ngrokClasses {
+			if class.Annotations["ingressclass.kubernetes.io/is-default-class"] == "true" {
+				return true, nil
+			}
+		}
+	}
+	return false, errors.NewErrDifferentIngressClass(s.ListNgrokIngressClassesV1(), ing.Spec.IngressClassName)
+}
+
+// shouldHandleIngressIsValid checks if the ingress should be handled by the controller based on the ingress spec
+func (s Store) shouldHandleIngressIsValid(ing *netv1.Ingress) (bool, error) {
+	errs := errors.NewErrInvalidIngressSpec()
+	if len(ing.Spec.Rules) > 1 {
+		errs.AddError(fmt.Sprintf("A maximum of one rule is required to be set"))
+	}
+	if len(ing.Spec.Rules) == 0 {
+		errs.AddError(fmt.Sprintf("At least one rule is required to be set"))
+	} else {
+		if ing.Spec.Rules[0].Host == "" {
+			errs.AddError(fmt.Sprintf("A host is required to be set"))
+		}
+
+		for _, path := range ing.Spec.Rules[0].HTTP.Paths {
+			if path.Backend.Resource != nil {
+				errs.AddError(fmt.Sprintf("Resource backends are not supported"))
+			}
+		}
+	}
+
+	if errs.HasErrors() {
+		return false, errs
+	}
+	return true, nil
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,164 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	netv1 "k8s.io/api/networking/v1"
+)
+
+const controllerName = "k8s.ngrok.com/ingress-controller" // TODO: Move this into a variable thats shared
+const ngrokIngressClass = "ngrok"
+
+func TestStore(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Store package Test Suite")
+}
+
+var _ = Describe("Store", func() {
+
+	var store Storer
+	BeforeEach(func() {
+		// create a fake logger to pass into the cachestore
+		logger := logr.New(logr.Discard().GetSink())
+		cacheStores := NewCacheStores(logger)
+		store = New(cacheStores, controllerName, logger)
+	})
+
+	var _ = Describe("GetIngressClassV1", func() {
+		Context("when the ingress class exists", func() {
+			BeforeEach(func() {
+				ic := NewTestIngressClass(ngrokIngressClass, true, true)
+				store.Add(&ic)
+			})
+			It("returns the ingress class", func() {
+				ic, err := store.GetIngressClassV1(ngrokIngressClass)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ic.Name).To(Equal(ngrokIngressClass))
+			})
+		})
+		Context("when the ingress class does not exist", func() {
+			It("returns an error", func() {
+				ic, err := store.GetIngressClassV1("does-not-exist")
+				Expect(err).To(HaveOccurred())
+				Expect(ic).To(BeNil())
+			})
+		})
+	})
+
+	var _ = Describe("GetIngressV1", func() {
+		Context("when the ingress exists", func() {
+			BeforeEach(func() {
+				ing := NewTestIngressV1("test-ingress", "test-namespace")
+				store.Add(&ing)
+			})
+			It("returns the ingress", func() {
+				ing, err := store.GetIngressV1("test-ingress", "test-namespace")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ing.Name).To(Equal("test-ingress"))
+			})
+		})
+		Context("when the ingress does not exist", func() {
+			It("returns an error", func() {
+				ing, err := store.GetIngressV1("does-not-exist", "does-not-exist")
+				Expect(err).To(HaveOccurred())
+				Expect(ing).To(BeNil())
+			})
+		})
+	})
+
+	var _ = Describe("GetNgrokIngressV1", func() {
+		Context("when the ngrok ingress exists", func() {
+			BeforeEach(func() {
+				ing := NewTestIngressV1WithClass("test-ingress", "test-namespace", ngrokIngressClass)
+				store.Add(&ing)
+				ic := NewTestIngressClass(ngrokIngressClass, true, true)
+				store.Add(&ic)
+			})
+			It("returns the ngrok ingress", func() {
+				ing, err := store.GetNgrokIngressV1("test-ingress", "test-namespace")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ing.Name).To(Equal("test-ingress"))
+			})
+			It("Filters out ingresses that don't match the ngrok ingress class", func() {
+				ingNotNgrok := NewTestIngressV1WithClass("ingNotNgrok", "test-namespace", "not-ngrok")
+				store.Add(&ingNotNgrok)
+
+				ing, err := store.GetNgrokIngressV1("ingNotNgrok", "test-namespace")
+				Expect(err).To(HaveOccurred())
+				Expect(ing).To(BeNil())
+			})
+			It("Filters finds ones without a class if we are default", func() {
+				ingNoClass := NewTestIngressV1("ingNoClass", "test-namespace")
+				store.Add(&ingNoClass)
+
+				ing, err := store.GetNgrokIngressV1("ingNoClass", "test-namespace")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ing.Name).To(Equal("ingNoClass"))
+			})
+		})
+		Context("when the ngrok ingress does not exist", func() {
+			It("returns an error", func() {
+				ing, err := store.GetNgrokIngressV1("does-not-exist", "does-not-exist")
+				Expect(err).To(HaveOccurred())
+				Expect(ing).To(BeNil())
+			})
+		})
+	})
+
+	var _ = Describe("ListNgrokIngressClassesV1", func() {
+		Context("when there are ngrok ingress classes", func() {
+			BeforeEach(func() {
+				ic1 := NewTestIngressClass("ngrok1", true, true)
+				store.Add(&ic1)
+				ic2 := NewTestIngressClass("ngrok2", true, true)
+				store.Add(&ic2)
+				ic3 := NewTestIngressClass("different", true, false)
+				store.Add(&ic3)
+			})
+			It("returns the ngrok ingress classes and doesn't return the different one", func() {
+				ics := store.ListNgrokIngressClassesV1()
+				Expect(len(ics)).To(Equal(2))
+			})
+		})
+		Context("when there are no ngrok ingress classes", func() {
+			It("doesn't error", func() {
+				ics := store.ListNgrokIngressClassesV1()
+				Expect(len(ics)).To(Equal(0))
+			})
+		})
+	})
+
+	var _ = Describe("ListNgrokIngressesV1", func() {
+		icUsDefault := NewTestIngressClass("ngrok", true, true)
+		icUsNotDefault := NewTestIngressClass("ngrok", false, true)
+		icOtherDefault := NewTestIngressClass("test", true, false)
+		icOtherNotDefault := NewTestIngressClass("test", false, false)
+
+		var _ = DescribeTable("IngressClassFiltering", func(ingressClasses []netv1.IngressClass, expectedMatchingIngressesCount int) {
+			iMatching := NewTestIngressV1WithClass("test1", "test", "ngrok")
+			iNotMatching := NewTestIngressV1WithClass("test2", "test", "test")
+			iNoClass := NewTestIngressV1("test3", "test")
+			store.Add(&iMatching)
+			store.Add(&iNotMatching)
+			store.Add(&iNoClass)
+			for _, ic := range ingressClasses {
+				store.Add(&ic)
+			}
+			ings := store.ListNgrokIngressesV1()
+			Expect(len(ings)).To(Equal(expectedMatchingIngressesCount))
+		},
+			Entry("No ingress classes", []netv1.IngressClass{}, 0),
+			Entry("just us not as default", []netv1.IngressClass{icUsNotDefault}, 1),
+			Entry("just us as default", []netv1.IngressClass{icUsDefault}, 2),
+			Entry("just another not as default", []netv1.IngressClass{icOtherNotDefault}, 0),
+			Entry("just another as default", []netv1.IngressClass{icOtherDefault}, 0),
+			Entry("us and another neither default", []netv1.IngressClass{icUsNotDefault, icOtherNotDefault}, 1),
+			Entry("us and another them default", []netv1.IngressClass{icUsNotDefault, icOtherDefault}, 1),
+			Entry("us and another us default", []netv1.IngressClass{icUsDefault, icOtherNotDefault}, 2),
+			Entry("us and another both default", []netv1.IngressClass{icUsDefault, icOtherDefault}, 2),
+		)
+	})
+})

--- a/internal/store/testutility.go
+++ b/internal/store/testutility.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewTestIngressClass(name string, isDefault bool, isNgrok bool) netv1.IngressClass {
+	i := netv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"app.kubernetes.io/component": "controller",
+			},
+		},
+	}
+
+	if isNgrok {
+		i.Spec.Controller = controllerName
+	} else {
+		i.Spec.Controller = "kubernetes.io/ingress-other"
+	}
+
+	if isDefault {
+		i.Annotations = map[string]string{
+			"ingressclass.kubernetes.io/is-default-class": "true", // TODO: Move this into a utility for ingress classes
+		}
+	}
+
+	return i
+}
+
+func NewTestIngressV1WithClass(name string, namespace string, ingressClass string) netv1.Ingress {
+	i := NewTestIngressV1(name, namespace)
+	i.Spec.IngressClassName = &ingressClass
+	return i
+}
+
+func NewTestIngressV1(name string, namespace string) netv1.Ingress {
+	return netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: netv1.IngressSpec{
+			Rules: []netv1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: netv1.IngressRuleValue{
+						HTTP: &netv1.HTTPIngressRuleValue{
+							Paths: []netv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: netv1.IngressBackend{
+										Service: &netv1.IngressServiceBackend{
+											Name: "example",
+											Port: netv1.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
Creates the basic Store and CacheStores with getter/setter functions for managing our ingress and CRD resources

## How
cachestores is an in-memory cache being used to back the store. The majority of its actual logic is around filtering out ingress classes. After having done this, I now wonder if it would have been easier to just use a predicate filter to ignore non-matching ingresses and just never add them to the store. We can always delete code and go that way in the future if we want

## Breaking Changes
none, this is new
