### PR TITLE
Alex/update release docs rename

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -86,8 +86,8 @@ jobs:
             const release = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: `ngrok-ingress-controller-${tag}`,
-              name: `ngrok-ingress-controller-${tag}`,
+              tag_name: `kubernetes-ingress-controller-${tag}`,
+              name: `kubernetes-ingress-controller-${tag}`,
               body: `${tag}`,
               draft: false,
               prerelease: false

--- a/api/v1alpha1/ngrok_common.go
+++ b/api/v1alpha1/ngrok_common.go
@@ -3,10 +3,10 @@ package v1alpha1
 // common ngrok API/Dashboard fields
 type ngrokAPICommon struct {
 	// Description is a human-readable description of the object in the ngrok API/Dashboard
-	// +kubebuilder:default:=`Created by ngrok-ingress-controller`
+	// +kubebuilder:default:=`Created by kubernetes-ingress-controller`
 	Description string `json:"description,omitempty"`
 	// Metadata is a string of arbitrary data associated with the object in the ngrok API/Dashboard
-	// +kubebuilder:default:=`{"owned-by":"ngrok-ingress-controller"}`
+	// +kubebuilder:default:=`{"owned-by":"kubernetes-ingress-controller"}`
 	Metadata string `json:"metadata,omitempty"`
 }
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,23 +13,23 @@
 ## Artifacts
 
 The ngrok Ingress Controller has 2 main artifacts, a docker image and a helm chart.
-While the helm chart is the recommended way to install the Ingress Controller, the 
+While the helm chart is the recommended way to install the Ingress Controller, the
 docker image can be used to run the Ingress Controller in a Kubernetes cluster without helm.
 
 ### Docker Image
 
-The Docker image contains the ngrok Ingress Controller binary and is available on 
+The Docker image contains the ngrok Ingress Controller binary and is available on
 Docker Hub [here](https://hub.docker.com/r/ngrok/kubernetes-ingress-controller). We currently
 support `amd64` and `arm64` architectures, with future plans to build for other architectures.
 
 ### Helm Chart
 
-The helm chart is packaged and published to its own [helm repository](https://ngrok.github.io/ngrok-ingress-controller/index.yaml)
+The helm chart is packaged and published to its own [helm repository](https://ngrok.github.io/kubernetes-ingress-controller/index.yaml)
 and can be installed by following the instructions in the chart's [README](../helm/ingress-controller/README.md).
 
 ## Semantic Versioning
 
-This project uses [semantic versioning](https://semver.org/) for both the the docker image 
+This project uses [semantic versioning](https://semver.org/) for both the the docker image
 and helm chart. Please note that this project is still under development(pre 1.0.0) and considered `alpha` status at this time.
 
 From the [semver spec](https://semver.org/#spec-item-4):
@@ -45,7 +45,7 @@ release in both.
 
 ### Tagging
 
-There is a different git tag pattern for each artifact. 
+There is a different git tag pattern for each artifact.
 
 #### Helm Chart
 
@@ -62,8 +62,8 @@ to the semantic versioning spec as described above.
 
 #### Controller
 
-Releases of the controller will be tagged with a prefix of `ngrok-ingress-controller-`. For example,
-version `1.2.0` of the docker image will have a git tag of `ngrok-ingress-controller-1.2.0` which
+Releases of the controller will be tagged with a prefix of `kubernetes-ingress-controller-`. For example,
+version `1.2.0` of the docker image will have a git tag of `kubernetes-ingress-controller-1.2.0` which
 contains the code used to build the docker image `ngrok/kubernetes-ingress-controller:1.2.0`.
 
 When changes that would affect the controller's docker image are pushed to `main`, a github workflow
@@ -72,5 +72,5 @@ image.
 
 If the `VERSION` file at the root of the repo is changed, the workflow will also create a git tag
 for the controller as described above and publish a tagged docker image. For instance when the
-`VERSION` is changed to `1.2.0`, the workflow will create a git tag of `ngrok-ingress-controller-1.2.0`
+`VERSION` is changed to `1.2.0`, the workflow will create a git tag of `kubernetes-ingress-controller-1.2.0`
 and publish the docker image `ngrok/kubernetes-ingress-controller:1.2.0`.

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -17,7 +17,7 @@ Helm's [documentation](https://helm.sh/docs) to get started.
 
 Once Helm has been set up correctly, add the repo as follows:
 
-`helm repo add ngrok https://ngrok.github.io/ngrok-ingress-controller`
+`helm repo add ngrok https://ngrok.github.io/kubernetes-ingress-controller`
 
 If you had already added this repo earlier, run `helm repo update` to retrieve
 the latest versions of the packages.  You can then run `helm search repo ngrok` to see the charts.

--- a/helm/ingress-controller/templates/crds/ingress.k8s.ngrok.com_domains.yaml
+++ b/helm/ingress-controller/templates/crds/ingress.k8s.ngrok.com_domains.yaml
@@ -57,7 +57,7 @@ spec:
             description: DomainSpec defines the desired state of Domain
             properties:
               description:
-                default: Created by ngrok-ingress-controller
+                default: Created by kubernetes-ingress-controller
                 description: Description is a human-readable description of the object
                   in the ngrok API/Dashboard
                 type: string
@@ -65,7 +65,7 @@ spec:
                 description: Domain is the domain name to reserve
                 type: string
               metadata:
-                default: '{"owned-by":"ngrok-ingress-controller"}'
+                default: '{"owned-by":"kubernetes-ingress-controller"}'
                 description: Metadata is a string of arbitrary data associated with
                   the object in the ngrok API/Dashboard
                 type: string

--- a/helm/ingress-controller/templates/crds/ingress.k8s.ngrok.com_httpsedges.yaml
+++ b/helm/ingress-controller/templates/crds/ingress.k8s.ngrok.com_httpsedges.yaml
@@ -36,7 +36,7 @@ spec:
             description: HTTPSEdgeSpec defines the desired state of HTTPSEdge
             properties:
               description:
-                default: Created by ngrok-ingress-controller
+                default: Created by kubernetes-ingress-controller
                 description: Description is a human-readable description of the object
                   in the ngrok API/Dashboard
                 type: string
@@ -46,7 +46,7 @@ spec:
                   type: string
                 type: array
               metadata:
-                default: '{"owned-by":"ngrok-ingress-controller"}'
+                default: '{"owned-by":"kubernetes-ingress-controller"}'
                 description: Metadata is a string of arbitrary data associated with
                   the object in the ngrok API/Dashboard
                 type: string
@@ -59,7 +59,7 @@ spec:
                         backend that serves traffic for this edge
                       properties:
                         description:
-                          default: Created by ngrok-ingress-controller
+                          default: Created by kubernetes-ingress-controller
                           description: Description is a human-readable description
                             of the object in the ngrok API/Dashboard
                           type: string
@@ -69,7 +69,7 @@ spec:
                           description: Labels to watch for tunnels on this backend
                           type: object
                         metadata:
-                          default: '{"owned-by":"ngrok-ingress-controller"}'
+                          default: '{"owned-by":"kubernetes-ingress-controller"}'
                           description: Metadata is a string of arbitrary data associated
                             with the object in the ngrok API/Dashboard
                           type: string
@@ -84,7 +84,7 @@ spec:
                           type: boolean
                       type: object
                     description:
-                      default: Created by ngrok-ingress-controller
+                      default: Created by kubernetes-ingress-controller
                       description: Description is a human-readable description of
                         the object in the ngrok API/Dashboard
                       type: string
@@ -151,7 +151,7 @@ spec:
                       - path_prefix
                       type: string
                     metadata:
-                      default: '{"owned-by":"ngrok-ingress-controller"}'
+                      default: '{"owned-by":"kubernetes-ingress-controller"}'
                       description: Metadata is a string of arbitrary data associated
                         with the object in the ngrok API/Dashboard
                       type: string

--- a/helm/ingress-controller/templates/crds/ingress.k8s.ngrok.com_ippolicies.yaml
+++ b/helm/ingress-controller/templates/crds/ingress.k8s.ngrok.com_ippolicies.yaml
@@ -45,12 +45,12 @@ spec:
             description: IPPolicySpec defines the desired state of IPPolicy
             properties:
               description:
-                default: Created by ngrok-ingress-controller
+                default: Created by kubernetes-ingress-controller
                 description: Description is a human-readable description of the object
                   in the ngrok API/Dashboard
                 type: string
               metadata:
-                default: '{"owned-by":"ngrok-ingress-controller"}'
+                default: '{"owned-by":"kubernetes-ingress-controller"}'
                 description: Metadata is a string of arbitrary data associated with
                   the object in the ngrok API/Dashboard
                 type: string
@@ -63,12 +63,12 @@ spec:
                     cidr:
                       type: string
                     description:
-                      default: Created by ngrok-ingress-controller
+                      default: Created by kubernetes-ingress-controller
                       description: Description is a human-readable description of
                         the object in the ngrok API/Dashboard
                       type: string
                     metadata:
-                      default: '{"owned-by":"ngrok-ingress-controller"}'
+                      default: '{"owned-by":"kubernetes-ingress-controller"}'
                       description: Metadata is a string of arbitrary data associated
                         with the object in the ngrok API/Dashboard
                       type: string

--- a/helm/ingress-controller/templates/crds/ingress.k8s.ngrok.com_tcpedges.yaml
+++ b/helm/ingress-controller/templates/crds/ingress.k8s.ngrok.com_tcpedges.yaml
@@ -57,7 +57,7 @@ spec:
                   that serves traffic for this edge
                 properties:
                   description:
-                    default: Created by ngrok-ingress-controller
+                    default: Created by kubernetes-ingress-controller
                     description: Description is a human-readable description of the
                       object in the ngrok API/Dashboard
                     type: string
@@ -67,13 +67,13 @@ spec:
                     description: Labels to watch for tunnels on this backend
                     type: object
                   metadata:
-                    default: '{"owned-by":"ngrok-ingress-controller"}'
+                    default: '{"owned-by":"kubernetes-ingress-controller"}'
                     description: Metadata is a string of arbitrary data associated
                       with the object in the ngrok API/Dashboard
                     type: string
                 type: object
               description:
-                default: Created by ngrok-ingress-controller
+                default: Created by kubernetes-ingress-controller
                 description: Description is a human-readable description of the object
                   in the ngrok API/Dashboard
                 type: string
@@ -86,7 +86,7 @@ spec:
                     type: array
                 type: object
               metadata:
-                default: '{"owned-by":"ngrok-ingress-controller"}'
+                default: '{"owned-by":"kubernetes-ingress-controller"}'
                 description: Metadata is a string of arbitrary data associated with
                   the object in the ngrok API/Dashboard
                 type: string


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
Recently the repo, the docker image, and the helm chart url (by virtue of being hosted on our github pages) had their name changed from `ngrok-ingress-controller` to `kubernetes-ingress-controller`. We updated the repo so builds passed, but i found a few spots I think should be updated. 

## How
- A couple of spots were just documentation
- one is for the default metadata we use. Instead of specifying "ngrok", since its in the ngrok api, the "Kubernetes" has more meaningful context.
- the last is the release name. The last release still showed the old name https://github.com/ngrok/kubernetes-ingress-controller/releases/tag/ngrok-ingress-controller-0.3.0

## Breaking Changes
No, well kind of but we are changing the release name on purpose :) 
