### PR TITLE
Only apply an update to the domain if its actually different

### DIFF
--- a/api/v1alpha1/domain_types.go
+++ b/api/v1alpha1/domain_types.go
@@ -96,35 +96,20 @@ func init() {
 	SchemeBuilder.Register(&Domain{}, &DomainList{})
 }
 
-// SetStatus updates the status of the domain from the ngrok API
-// object. Returns true if the status has changed.
-func (d *Domain) SetStatus(ngrokDomain *ngrok.ReservedDomain) bool {
-	changed := false
+// SetStatus pulls the fields off the ngrok domain and sets each one on the status field of the domain
+func (d *Domain) SetStatus(ngrokDomain *ngrok.ReservedDomain) {
+	d.Status.ID = ngrokDomain.ID
+	d.Status.Region = ngrokDomain.Region
+	d.Status.Domain = ngrokDomain.Domain
+	d.Status.URI = ngrokDomain.URI
+	d.Status.CNAMETarget = ngrokDomain.CNAMETarget
+}
 
-	if d.Status.ID != ngrokDomain.ID {
-		d.Status.ID = ngrokDomain.ID
-		changed = true
-	}
-
-	if d.Status.Region != ngrokDomain.Region {
-		d.Status.Region = ngrokDomain.Region
-		changed = true
-	}
-
-	if d.Status.Domain != ngrokDomain.Domain {
-		d.Status.Domain = ngrokDomain.Domain
-		changed = true
-	}
-
-	if d.Status.URI != ngrokDomain.URI {
-		d.Status.URI = ngrokDomain.URI
-		changed = true
-	}
-
-	if d.Status.CNAMETarget != ngrokDomain.CNAMETarget {
-		d.Status.CNAMETarget = ngrokDomain.CNAMETarget
-		changed = true
-	}
-
-	return changed
+// Equal returns true if the domain status is equal to the ngrok domain
+func (d *Domain) Equal(ngrokDomain *ngrok.ReservedDomain) bool {
+	return d.Status.ID == ngrokDomain.ID &&
+		d.Status.Region == ngrokDomain.Region &&
+		d.Status.Domain == ngrokDomain.Domain &&
+		d.Status.URI == ngrokDomain.URI &&
+		d.Status.CNAMETarget == ngrokDomain.CNAMETarget
 }

--- a/api/v1alpha1/domain_types.go
+++ b/api/v1alpha1/domain_types.go
@@ -25,6 +25,7 @@ SOFTWARE.
 package v1alpha1
 
 import (
+	"github.com/ngrok/ngrok-api-go/v5"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -93,4 +94,37 @@ type DomainList struct {
 
 func init() {
 	SchemeBuilder.Register(&Domain{}, &DomainList{})
+}
+
+// SetStatus updates the status of the domain from the ngrok API
+// object. Returns true if the status has changed.
+func (d *Domain) SetStatus(ngrokDomain *ngrok.ReservedDomain) bool {
+	changed := false
+
+	if d.Status.ID != ngrokDomain.ID {
+		d.Status.ID = ngrokDomain.ID
+		changed = true
+	}
+
+	if d.Status.Region != ngrokDomain.Region {
+		d.Status.Region = ngrokDomain.Region
+		changed = true
+	}
+
+	if d.Status.Domain != ngrokDomain.Domain {
+		d.Status.Domain = ngrokDomain.Domain
+		changed = true
+	}
+
+	if d.Status.URI != ngrokDomain.URI {
+		d.Status.URI = ngrokDomain.URI
+		changed = true
+	}
+
+	if d.Status.CNAMETarget != ngrokDomain.CNAMETarget {
+		d.Status.CNAMETarget = ngrokDomain.CNAMETarget
+		changed = true
+	}
+
+	return changed
 }

--- a/internal/controllers/domain_controller.go
+++ b/internal/controllers/domain_controller.go
@@ -188,30 +188,10 @@ func (r *DomainReconciler) findReservedDomainByHostname(ctx context.Context, dom
 
 // updateStatus updates the status fields of the domain resource only if any values have changed
 func (r *DomainReconciler) updateStatus(ctx context.Context, domain *ingressv1alpha1.Domain, ngrokDomain *ngrok.ReservedDomain) error {
-	dirty := false
-	if domain.Status.ID != ngrokDomain.ID {
-		domain.Status.ID = ngrokDomain.ID
-		dirty = true
-	}
-	if domain.Status.CNAMETarget != ngrokDomain.CNAMETarget {
-		domain.Status.CNAMETarget = ngrokDomain.CNAMETarget
-		dirty = true
-	}
-	if domain.Status.URI != ngrokDomain.URI {
-		domain.Status.URI = ngrokDomain.URI
-		dirty = true
-	}
-	if domain.Status.Domain != ngrokDomain.Domain {
-		domain.Status.Domain = ngrokDomain.Domain
-		dirty = true
-	}
-	if domain.Status.Region != ngrokDomain.Region {
-		domain.Status.Region = ngrokDomain.Region
-		dirty = true
-	}
-
-	if dirty {
+	changed := domain.SetStatus(ngrokDomain)
+	if changed {
 		if err := r.Status().Update(ctx, domain); err != nil {
+			r.Recorder.Event(domain, v1.EventTypeNormal, "Updated", fmt.Sprintf("Updated Domain %s", domain.Name))
 			return err
 		}
 	}

--- a/internal/controllers/domain_controller.go
+++ b/internal/controllers/domain_controller.go
@@ -190,7 +190,7 @@ func (r *DomainReconciler) findReservedDomainByHostname(ctx context.Context, dom
 func (r *DomainReconciler) updateStatus(ctx context.Context, domain *ingressv1alpha1.Domain, ngrokDomain *ngrok.ReservedDomain) error {
 	changed := domain.SetStatus(ngrokDomain)
 	if changed {
-		r.Recorder.Event(domain, v1.EventTypeNormal, "Updated", fmt.Sprintf("Updated Domain %s", domain.Name))
+		r.Recorder.Event(domain, v1.EventTypeNormal, "Updated", fmt.Sprintf("Updating Domain %s", domain.Name))
 		if err := r.Status().Update(ctx, domain); err != nil {
 			return err
 		}

--- a/internal/controllers/domain_controller.go
+++ b/internal/controllers/domain_controller.go
@@ -190,8 +190,8 @@ func (r *DomainReconciler) findReservedDomainByHostname(ctx context.Context, dom
 func (r *DomainReconciler) updateStatus(ctx context.Context, domain *ingressv1alpha1.Domain, ngrokDomain *ngrok.ReservedDomain) error {
 	changed := domain.SetStatus(ngrokDomain)
 	if changed {
+		r.Recorder.Event(domain, v1.EventTypeNormal, "Updated", fmt.Sprintf("Updated Domain %s", domain.Name))
 		if err := r.Status().Update(ctx, domain); err != nil {
-			r.Recorder.Event(domain, v1.EventTypeNormal, "Updated", fmt.Sprintf("Updated Domain %s", domain.Name))
 			return err
 		}
 	}

--- a/internal/controllers/domain_controller.go
+++ b/internal/controllers/domain_controller.go
@@ -188,13 +188,10 @@ func (r *DomainReconciler) findReservedDomainByHostname(ctx context.Context, dom
 
 // updateStatus updates the status fields of the domain resource only if any values have changed
 func (r *DomainReconciler) updateStatus(ctx context.Context, domain *ingressv1alpha1.Domain, ngrokDomain *ngrok.ReservedDomain) error {
-	changed := domain.SetStatus(ngrokDomain)
-	if changed {
-		r.Recorder.Event(domain, v1.EventTypeNormal, "Updated", fmt.Sprintf("Updating Domain %s", domain.Name))
-		if err := r.Status().Update(ctx, domain); err != nil {
-			return err
-		}
+	if domain.Equal(ngrokDomain) {
+		return nil
 	}
-
-	return nil
+	domain.SetStatus(ngrokDomain)
+	r.Recorder.Event(domain, v1.EventTypeNormal, "Updated", fmt.Sprintf("Updating Domain %s", domain.Name))
+	return r.Status().Update(ctx, domain)
 }


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
On startup, the controller gets events for every object it watches. This includes domains. So whenever a controller pod starts it lists out all the domains with worthless updates that trigger more reconcile loops. 

## How
The domain object isn't large, this checks if any fields are actually different before making an update call 

## Breaking Changes
No
