### PR TITLE
Alex/watch single namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ deploy: docker-build manifests kustomize ## Deploy controller to the K8s cluster
 		--create-namespace \
 		--set podAnnotations."k8s\.ngrok\.com/test"="\{\"env\": \"local\"\}" \
 		--set image.repository=$(IMG) \
+		--set watchNamespace="default" \
 		--set credentials.apiKey=$(NGROK_API_KEY) \
 		--set credentials.authtoken=$(NGROK_AUTHTOKEN) && \
 	kubectl rollout restart deployment ngrok-ingress-controller-kubernetes-ingress-controller-manager -n ngrok-ingress-controller

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,6 @@ deploy: docker-build manifests kustomize ## Deploy controller to the K8s cluster
 		--create-namespace \
 		--set podAnnotations."k8s\.ngrok\.com/test"="\{\"env\": \"local\"\}" \
 		--set image.repository=$(IMG) \
-		--set watchNamespace="default" \
 		--set credentials.apiKey=$(NGROK_API_KEY) \
 		--set credentials.authtoken=$(NGROK_AUTHTOKEN) && \
 	kubectl rollout restart deployment ngrok-ingress-controller-kubernetes-ingress-controller-manager -n ngrok-ingress-controller

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -57,6 +57,7 @@ To uninstall the chart:
 | `ingressClass.name`          | The name of the ingress class to use.                                                                                 | `ngrok`                               |
 | `ingressClass.create`        | Whether to create the ingress class.                                                                                  | `true`                                |
 | `ingressClass.default`       | Whether to set the ingress class as default.                                                                          | `false`                               |
+| `watchNamespace`             | The namespace to watch for ingress resources. Defaults to all                                                         | `""`                                  |
 | `credentials.secret.name`    | The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.    | `""`                                  |
 | `credentials.apiKey`         | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well. | `""`                                  |
 | `credentials.authtoken`      | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.  | `""`                                  |

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -48,6 +48,9 @@ spec:
         {{- if .Values.serverAddr }}
         - --server-addr={{ .Values.serverAddr}}
         {{- end }}
+        {{- if .Values.watchNamespace }}
+        - --watch-namespace={{ .Values.watchNamespace}}
+        {{- end }}
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --election-id={{ include "kubernetes-ingress-controller.fullname" . }}-leader

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -48,7 +48,7 @@ ingressClass:
   create: true
   default: false
 
-## @param watchNamespace The namespace to watch for ingress resources.
+## @param watchNamespace The namespace to watch for ingress resources. Defaults to all
 watchNamespace: ""
 
 ## @param credentials.secret.name The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -48,6 +48,9 @@ ingressClass:
   create: true
   default: false
 
+## @param watchNamespace The namespace to watch for ingress resources.
+watchNamespace: ""
+
 ## @param credentials.secret.name The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.
 ## @param credentials.apiKey Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well.
 ## @param credentials.authtoken Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #64

## What
It is pretty common to want to make an ingress controller only monitor a specific namespace. It is an option built into the controller-runtime manager, and this just makes it configurable via helm. 
```
 k get ing -A
NAMESPACE                  NAME                           CLASS   HOSTS                                   ADDRESS   PORTS   AGE
ngrok-ingress-controller   minimal-ingress                ngrok   bezek-hello-world-ingress.ngrok.io                80      3d16h
other                      minimal-ingress-2-namespaced   ngrok   bezek-hello-world-namespaced.ngrok.io             80      2m54s
```
Here you can see i created ingress objects in multiple namespaces. I installed the controller with this set flag
`--set watchNamespace="ngrok-ingress-controller"` and it correctly only created the 1 edge

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/8029578/220487456-61b54b3a-eeab-4cf2-bf93-11d6d07a56c2.png">


## How
Simply takes a namespace string to pass to the manager. Some controllers allow you to pass multiple namespaces which we could support later if needed. 

## Breaking Changes
No, the default behaviour is to watch all namespaces
