### PR TITLE
Make controller name configurable so multiple can be installed in a c…

### DIFF
--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -57,6 +57,7 @@ To uninstall the chart:
 | `ingressClass.name`          | The name of the ingress class to use.                                                                                 | `ngrok`                               |
 | `ingressClass.create`        | Whether to create the ingress class.                                                                                  | `true`                                |
 | `ingressClass.default`       | Whether to set the ingress class as default.                                                                          | `false`                               |
+| `controllerName`             | The name of the controller to look for matching ingress classes                                                       | `k8s.ngrok.com/ingress-controller`    |
 | `credentials.secret.name`    | The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.    | `""`                                  |
 | `credentials.apiKey`         | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well. | `""`                                  |
 | `credentials.authtoken`      | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.  | `""`                                  |

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -48,6 +48,7 @@ spec:
         {{- if .Values.serverAddr }}
         - --server-addr={{ .Values.serverAddr}}
         {{- end }}
+        - --controller-name={{ .Values.controllerName }}
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --election-id={{ include "kubernetes-ingress-controller.fullname" . }}-leader

--- a/helm/ingress-controller/templates/ingress-class.yaml
+++ b/helm/ingress-controller/templates/ingress-class.yaml
@@ -11,5 +11,5 @@ metadata:
     ingressclass.kubernetes.io/is-default-class: "true"
   {{- end }}
 spec:
-  controller: k8s.ngrok.com/ingress-controller
+  controller: {{ .Values.controllerName }}
 {{- end}}

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -38,6 +38,7 @@ Should match all-options snapshot:
         spec:
           containers:
           - args:
+            - --controller-name=k8s.ngrok.com/ingress-controller
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8080
             - --election-id=RELEASE-NAME-kubernetes-ingress-controller-leader
@@ -427,6 +428,7 @@ Should match default snapshot:
         spec:
           containers:
           - args:
+            - --controller-name=k8s.ngrok.com/ingress-controller
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8080
             - --election-id=RELEASE-NAME-kubernetes-ingress-controller-leader

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -48,6 +48,9 @@ ingressClass:
   create: true
   default: false
 
+## @param controllerName The name of the controller to look for matching ingress classes
+controllerName: "k8s.ngrok.com/ingress-controller"
+
 ## @param credentials.secret.name The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.
 ## @param credentials.apiKey Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well.
 ## @param credentials.authtoken Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -20,9 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// The name of the ingress controller which is uses to match on ingress classes
-const controllerName = "k8s.ngrok.com/ingress-controller" // TODO: Let the user configure this
-const clusterDomain = "svc.cluster.local"                 // TODO: We can technically figure this out by looking at things like our resolv.conf or we can just take this as a helm option
+const clusterDomain = "svc.cluster.local" // TODO: We can technically figure this out by looking at things like our resolv.conf or we can just take this as a helm option
 
 // Driver maintains the store of information, can derive new information from the store, and can
 // synchronize the desired state of the store to the actual state of the cluster.
@@ -37,7 +35,7 @@ type Driver struct {
 }
 
 // NewDriver creates a new driver with a basic logger and cache store setup
-func NewDriver(logger logr.Logger, scheme *runtime.Scheme) *Driver {
+func NewDriver(logger logr.Logger, scheme *runtime.Scheme, controllerName string) *Driver {
 	cacheStores := NewCacheStores(logger)
 	s := New(cacheStores, controllerName, logger)
 	return &Driver{

--- a/internal/store/driver_test.go
+++ b/internal/store/driver_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Driver", func() {
 	BeforeEach(func() {
 		// create a fake logger to pass into the cachestore
 		logger := logr.New(logr.Discard().GetSink())
-		driver = NewDriver(logger, scheme)
+		driver = NewDriver(logger, scheme, defaultControllerName)
 		driver.bypassReentranceCheck = true
 	})
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 const ngrokIngressClass = "ngrok"
+const defaultControllerName = "k8s.ngrok.com/ingress-controller"
 
 func TestStore(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -23,7 +24,7 @@ var _ = Describe("Store", func() {
 		// create a fake logger to pass into the cachestore
 		logger := logr.New(logr.Discard().GetSink())
 		cacheStores := NewCacheStores(logger)
-		store = New(cacheStores, controllerName, logger)
+		store = New(cacheStores, defaultControllerName, logger)
 	})
 
 	var _ = Describe("GetIngressClassV1", func() {

--- a/internal/store/testutility.go
+++ b/internal/store/testutility.go
@@ -17,7 +17,7 @@ func NewTestIngressClass(name string, isDefault bool, isNgrok bool) netv1.Ingres
 	}
 
 	if isNgrok {
-		i.Spec.Controller = controllerName
+		i.Spec.Controller = "k8s.ngrok.com/ingress-controller"
 	} else {
 		i.Spec.Controller = "kubernetes.io/ingress-other"
 	}


### PR DESCRIPTION
…luster at a time

<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #152

## What
While we currently offer a way for the user to change the ingress class name, they can't change the ingress class spec controller name that the controller uses to match on. This is required if you want to install multiple ngrok ingress controllers that watch specific/different ingress classes. 

## How
This simply plumbs through a helm value that is passed to the controller and used for the ingress class filtering logic

## Breaking Changes
No, the default is the same
