### PR TITLE
Alex/fix ingress status

### DIFF
--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -137,9 +137,6 @@ func (d *Driver) Sync(ctx context.Context, c client.Client) error {
 	desiredDomains := d.calculateDomains()
 	desiredEdges := d.calculateHTTPSEdges()
 	desiredTunnels := d.calculateTunnels()
-	fmt.Printf("desiredDomains: %v", desiredDomains)
-	fmt.Printf("desiredEdges: %v", desiredEdges)
-	fmt.Printf("desiredTunnels: %v", desiredTunnels)
 
 	currDomains := &ingressv1alpha1.DomainList{}
 	currEdges := &ingressv1alpha1.HTTPSEdgeList{}
@@ -412,12 +409,12 @@ func (d *Driver) calculateTunnels() []ingressv1alpha1.Tunnel {
 
 func (d *Driver) calculateIngressLoadBalancerIPStatus(ing *netv1.Ingress, c client.Reader) []netv1.IngressLoadBalancerIngress {
 	domains := &ingressv1alpha1.DomainList{}
-	hostnames := make(map[string]netv1.IngressLoadBalancerIngress)
 	if err := c.List(context.Background(), domains); err != nil {
 		d.log.Error(err, "failed to list domains")
 		return []netv1.IngressLoadBalancerIngress{}
 	}
 
+	hostnames := make(map[string]netv1.IngressLoadBalancerIngress)
 	for _, domain := range domains.Items {
 		for _, rule := range ing.Spec.Rules {
 			if rule.Host == domain.Spec.Domain && domain.Status.CNAMETarget != nil {

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -271,10 +271,10 @@ func (d *Driver) Sync(ctx context.Context, c client.Client) error {
 func (d *Driver) updateIngressStatuses(ctx context.Context, c client.Client) error {
 	ingresses := d.ListNgrokIngressesV1()
 	for _, ingress := range ingresses {
-		newLBIPStatus := d.calculateIngressLoadBalancerIPStatus(ingress)
+		newLBIPStatus := d.calculateIngressLoadBalancerIPStatus(ingress, c)
 		if !reflect.DeepEqual(ingress.Status.LoadBalancer.Ingress, newLBIPStatus) {
 			ingress.Status.LoadBalancer.Ingress = newLBIPStatus
-			if err := c.Update(ctx, ingress); err != nil {
+			if err := c.Status().Update(ctx, ingress); err != nil {
 				d.log.Error(err, "error updating ingress status", "ingress", ingress)
 				return err
 			}
@@ -410,20 +410,26 @@ func (d *Driver) calculateTunnels() []ingressv1alpha1.Tunnel {
 	return tunnels
 }
 
-func (d *Driver) calculateIngressLoadBalancerIPStatus(ing *netv1.Ingress) []netv1.IngressLoadBalancerIngress {
-	domains := d.calculateDomains()
-	status := []netv1.IngressLoadBalancerIngress{}
-	for _, rule := range ing.Spec.Rules {
-		// TODO: Handle rules without hosts
-		if rule.Host != "" {
-			for _, domain := range domains {
-				if rule.Host == domain.Spec.Domain && &domain.Status != nil && domain.Status.CNAMETarget != nil {
-					status = append(status, netv1.IngressLoadBalancerIngress{
-						IP: *domain.Status.CNAMETarget,
-					})
+func (d *Driver) calculateIngressLoadBalancerIPStatus(ing *netv1.Ingress, c client.Reader) []netv1.IngressLoadBalancerIngress {
+	domains := &ingressv1alpha1.DomainList{}
+	hostnames := make(map[string]netv1.IngressLoadBalancerIngress)
+	if err := c.List(context.Background(), domains); err != nil {
+		d.log.Error(err, "failed to list domains")
+		return []netv1.IngressLoadBalancerIngress{}
+	}
+
+	for _, domain := range domains.Items {
+		for _, rule := range ing.Spec.Rules {
+			if rule.Host == domain.Spec.Domain && domain.Status.CNAMETarget != nil {
+				hostnames[domain.Spec.Domain] = netv1.IngressLoadBalancerIngress{
+					Hostname: *domain.Status.CNAMETarget,
 				}
 			}
 		}
+	}
+	status := []netv1.IngressLoadBalancerIngress{}
+	for _, hostname := range hostnames {
+		status = append(status, hostname)
 	}
 	return status
 }

--- a/internal/store/driver_test.go
+++ b/internal/store/driver_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -20,6 +22,7 @@ var _ = Describe("Driver", func() {
 
 	var driver *Driver
 	var scheme = runtime.NewScheme()
+	cname := "cnametarget.com"
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(ingressv1alpha1.AddToScheme(scheme))
 	BeforeEach(func() {
@@ -145,6 +148,138 @@ var _ = Describe("Driver", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(foundTunnel).ToNot(BeNil())
 			})
+		})
+	})
+
+	Describe("calculateIngressLoadBalancerIPStatus", func() {
+		It("Should return the correct status", func() {
+			i1 := NewTestIngressV1("test-ingress", "test-namespace")
+			i1.Spec = netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
+					{
+						Host: "test-domain.com",
+					},
+				},
+			}
+			domainList := &ingressv1alpha1.DomainList{
+				Items: []ingressv1alpha1.Domain{
+					{
+						Spec: ingressv1alpha1.DomainSpec{
+							Domain: "test-domain.com",
+						},
+						Status: ingressv1alpha1.DomainStatus{
+							CNAMETarget: &cname,
+						},
+					},
+				},
+			}
+			c := fake.NewClientBuilder().WithLists(domainList).WithScheme(scheme).Build()
+
+			status := driver.calculateIngressLoadBalancerIPStatus(&i1, c)
+			Expect(len(status)).To(Equal(1))
+			Expect(status[0].Hostname).To(Equal(cname))
+		})
+
+		It("Should return empty status if no matching domain found", func() {
+			i1 := NewTestIngressV1("test-ingress", "test-namespace")
+			i1.Spec = netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
+					{
+						Host: "test-domain.com",
+					},
+				},
+			}
+			domainList := &ingressv1alpha1.DomainList{
+				Items: []ingressv1alpha1.Domain{
+					{
+						Spec: ingressv1alpha1.DomainSpec{
+							Domain: "another-domain.com",
+						},
+						Status: ingressv1alpha1.DomainStatus{
+							CNAMETarget: &cname,
+						},
+					},
+				},
+			}
+			c := fake.NewClientBuilder().WithLists(domainList).WithScheme(scheme).Build()
+
+			status := driver.calculateIngressLoadBalancerIPStatus(&i1, c)
+			Expect(len(status)).To(Equal(0))
+		})
+
+		It("Should return empty status if domain CNAME target is nil", func() {
+			i1 := NewTestIngressV1("test-ingress", "test-namespace")
+			i1.Spec = netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
+					{
+						Host: "test-domain.com",
+					},
+				},
+			}
+			domainList := &ingressv1alpha1.DomainList{
+				Items: []ingressv1alpha1.Domain{
+					{
+						Spec: ingressv1alpha1.DomainSpec{
+							Domain: "test-domain.com",
+						},
+						Status: ingressv1alpha1.DomainStatus{
+							CNAMETarget: nil,
+						},
+					},
+				},
+			}
+			c := fake.NewClientBuilder().WithLists(domainList).WithScheme(scheme).Build()
+
+			status := driver.calculateIngressLoadBalancerIPStatus(&i1, c)
+			Expect(len(status)).To(Equal(0))
+		})
+
+		It("Should return multiple statuses for multiple matching domains", func() {
+			cname1 := "cnametarget1.com"
+			cname2 := "cnametarget2.com"
+			i1 := NewTestIngressV1("test-ingress", "test-namespace")
+			i1.Spec = netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
+					{
+						Host: "test-domain1.com",
+					},
+					{
+						Host: "test-domain2.com",
+					},
+				},
+			}
+			domainList := &ingressv1alpha1.DomainList{
+				Items: []ingressv1alpha1.Domain{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-domain1.com",
+						},
+						Spec: ingressv1alpha1.DomainSpec{
+							Domain: "test-domain1.com",
+						},
+						Status: ingressv1alpha1.DomainStatus{
+							CNAMETarget: &cname1,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-domain2.com",
+						},
+						Spec: ingressv1alpha1.DomainSpec{
+							Domain: "test-domain2.com",
+						},
+						Status: ingressv1alpha1.DomainStatus{
+							CNAMETarget: &cname2,
+						},
+					},
+				},
+			}
+			c := fake.NewClientBuilder().WithLists(domainList).WithScheme(scheme).Build()
+
+			status := driver.calculateIngressLoadBalancerIPStatus(&i1, c)
+			Expect(len(status)).To(Equal(2))
+			Expect(status[0].Hostname).To(Equal(cname1))
+			Expect(status[1].Hostname).To(Equal(cname2))
 		})
 	})
 })


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #161

## What
Resolves the bug where the ingress status isn't being updated with the CNAME target for white label domains

## How
There were 2 primary problems that needed to be fixed:
- it was basing the calculations based on the calculated domains, not by fetching the actual domains. Since the cname value comes from the ngrok api and is then written to the domain CRD status, calculating the domain doesn't contain this value, so it was never passed onto the ingress object
- Additionally, the update call needed to be `.c.Status().Update(` instead to actually get the status to update

Added more unit tests around the function

## Breaking Changes
No
