### PR TITLE
Fix flakey test and add another

### DIFF
--- a/internal/store/driver_test.go
+++ b/internal/store/driver_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Driver", func() {
 			Expect(len(status)).To(Equal(0))
 		})
 
-		It("Should return multiple statuses for multiple matching domains", func() {
+		It("Should return multiple statuses for multiple different domains", func() {
 			cname1 := "cnametarget1.com"
 			cname2 := "cnametarget2.com"
 			i1 := NewTestIngressV1("test-ingress", "test-namespace")
@@ -278,8 +278,56 @@ var _ = Describe("Driver", func() {
 
 			status := driver.calculateIngressLoadBalancerIPStatus(&i1, c)
 			Expect(len(status)).To(Equal(2))
-			Expect(status[0].Hostname).To(Equal(cname1))
-			Expect(status[1].Hostname).To(Equal(cname2))
+			Expect(status[0].Hostname).To(Not(Equal(status[1].Hostname)))
+			for _, s := range status {
+				Expect(s.Hostname).To(SatisfyAny(Equal(cname1), Equal(cname2)))
+			}
+		})
+
+		It("Should only have a single status for multiple domains that match", func() {
+			cname1 := "cnametarget1.com"
+			cname2 := "cnametarget2.com"
+			i1 := NewTestIngressV1("test-ingress", "test-namespace")
+			i1.Spec = netv1.IngressSpec{
+				Rules: []netv1.IngressRule{
+					{
+						Host: "test-domain1.com",
+					},
+					{
+						Host: "test-domain1.com",
+					},
+				},
+			}
+			domainList := &ingressv1alpha1.DomainList{
+				Items: []ingressv1alpha1.Domain{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-domain1.com",
+						},
+						Spec: ingressv1alpha1.DomainSpec{
+							Domain: "test-domain1.com",
+						},
+						Status: ingressv1alpha1.DomainStatus{
+							CNAMETarget: &cname1,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-domain2.com",
+						},
+						Spec: ingressv1alpha1.DomainSpec{
+							Domain: "test-domain1.com",
+						},
+						Status: ingressv1alpha1.DomainStatus{
+							CNAMETarget: &cname2,
+						},
+					},
+				},
+			}
+			c := fake.NewClientBuilder().WithLists(domainList).WithScheme(scheme).Build()
+
+			status := driver.calculateIngressLoadBalancerIPStatus(&i1, c)
+			Expect(len(status)).To(Equal(1))
 		})
 	})
 })


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
- I wrote a flakey test that is in main and needs to be fixed. 

## How
- The test checks the status of the ingress object returned for 2 status objects at 0 and 1
- Golang (like many languages) randomizes the access to map keys, so the end result that's put in the slice isn't ordered
- This causes it to fail/pass randomly. Passing the test seed in doesn't reproduce it because it's not based on the rand seed, it's just how maps work in go. 
- fixed by ensuring the length is correct, making sure there are no duplicates, and then ensuring each shows up

## Breaking Changes
No, its just tests
