### PR TITLE
Use Chart appVersion if tag is not specified

### DIFF
--- a/helm/ingress-controller/CHANGELOG.md
+++ b/helm/ingress-controller/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1
+### Fixed
+- Default the image tag to the chart's `appVersion` for predictable installs. Previously, the helm chart would default to the `latest` image tag which can have breaking changes, notably with CRDs.
+
 ## 0.6.0
 ### Changed
 - Ingress Class has Default set to false [#109](https://github.com/ngrok/kubernetes-ingress-controller/pull/109)

--- a/helm/ingress-controller/Chart.yaml
+++ b/helm/ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubernetes-ingress-controller
 description: A Kubernetes ingress controller built using ngrok.
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.4.0
 keywords:
   - ngrok

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -51,7 +51,7 @@ To uninstall the chart:
 | `replicaCount`               | The number of controllers and agents to run.                                                                          | `1`                                   |
 | `image.registry`             | The ngrok ingress controller image registry.                                                                          | `docker.io`                           |
 | `image.repository`           | The ngrok ingress controller image repository.                                                                        | `ngrok/kubernetes-ingress-controller` |
-| `image.tag`                  | The ngrok ingress controller image tag.                                                                               | `latest`                              |
+| `image.tag`                  | The ngrok ingress controller image tag. Defaults to the chart's appVersion if not specified                           | `""`                                  |
 | `image.pullPolicy`           | The ngrok ingress controller image pull policy.                                                                       | `IfNotPresent`                        |
 | `image.pullSecrets`          | An array of imagePullSecrets to be used when pulling the image.                                                       | `[]`                                  |
 | `ingressClass.name`          | The name of the ingress class to use.                                                                                 | `ngrok`                               |

--- a/helm/ingress-controller/templates/_helpers.tpl
+++ b/helm/ingress-controller/templates/_helpers.tpl
@@ -82,6 +82,6 @@ Return the ngrok/ingress-controller image name
 {{- define "kubernetes-ingress-controller.image" -}}
 {{- $registryName := .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -13,7 +13,7 @@ Should match all-options snapshot:
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
         app.kubernetes.io/version: 0.4.0
-        helm.sh/chart: kubernetes-ingress-controller-0.6.0
+        helm.sh/chart: kubernetes-ingress-controller-0.6.1
       name: RELEASE-NAME-kubernetes-ingress-controller-manager
       namespace: NAMESPACE
     spec:
@@ -65,7 +65,7 @@ Should match all-options snapshot:
                 value: test-value
             - name: TEST_ENV_VAR
               value: test
-            image: docker.io/ngrok/kubernetes-ingress-controller:latest
+            image: docker.io/ngrok/kubernetes-ingress-controller:0.4.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:
@@ -400,7 +400,7 @@ Should match default snapshot:
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
         app.kubernetes.io/version: 0.4.0
-        helm.sh/chart: kubernetes-ingress-controller-0.6.0
+        helm.sh/chart: kubernetes-ingress-controller-0.6.1
       name: RELEASE-NAME-kubernetes-ingress-controller-manager
       namespace: NAMESPACE
     spec:
@@ -445,7 +445,7 @@ Should match default snapshot:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: docker.io/ngrok/kubernetes-ingress-controller:latest
+            image: docker.io/ngrok/kubernetes-ingress-controller:0.4.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
@@ -10,6 +10,6 @@ Should match the snapshot:
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
         app.kubernetes.io/version: 0.4.0
-        helm.sh/chart: kubernetes-ingress-controller-0.6.0
+        helm.sh/chart: kubernetes-ingress-controller-0.6.1
       name: test-release-kubernetes-ingress-controller
       namespace: test-namespace

--- a/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -10,7 +10,7 @@ Should match snapshot:
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
         app.kubernetes.io/version: 0.4.0
-        helm.sh/chart: kubernetes-ingress-controller-0.6.0
+        helm.sh/chart: kubernetes-ingress-controller-0.6.1
       name: ngrok
     spec:
       controller: k8s.ngrok.com/ingress-controller

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -26,13 +26,13 @@ replicaCount: 1
 
 ## @param image.registry The ngrok ingress controller image registry.
 ## @param image.repository The ngrok ingress controller image repository.
-## @param image.tag The ngrok ingress controller image tag.
+## @param image.tag The ngrok ingress controller image tag. Defaults to the chart's appVersion if not specified
 ## @param image.pullPolicy The ngrok ingress controller image pull policy.
 ## @param image.pullSecrets An array of imagePullSecrets to be used when pulling the image.
 image:
   registry: docker.io
   repository: ngrok/kubernetes-ingress-controller
-  tag: latest
+  tag: ""
   pullPolicy: IfNotPresent
   ## Example
   ## pullSecrets:


### PR DESCRIPTION
## What

If you follow the helm install instructions, it will install the most recent helm release `0.6.0` which defaults the docker image tag to `latest`. This causes issues since the helm chart does not have the CRDs that we recently added. For deterministic installs, we should default to using the `appVersion` in the `Chart.yaml` if  `image.tag` is not supplied.

## How

Change default `image.tag` from `latest` to `.Chart.AppVersion`
 
## Breaking Changes
No
