### PR TITLE
Bump Helm Chart version to 0.7.0

### DIFF
--- a/helm/ingress-controller/CHANGELOG.md
+++ b/helm/ingress-controller/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0
+
+### Added
+- Update `NgrokModuleSet` and `HTTPSEdge` CRD to support SAML and OAuth
+
+### Changed
+- Update appVersion to `0.5.0` to match the latest release of the controller.
+
 ## 0.6.1
 ### Fixed
 - Default the image tag to the chart's `appVersion` for predictable installs. Previously, the helm chart would default to the `latest` image tag which can have breaking changes, notably with CRDs.

--- a/helm/ingress-controller/Chart.yaml
+++ b/helm/ingress-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: kubernetes-ingress-controller
 description: A Kubernetes ingress controller built using ngrok.
-version: 0.6.1
-appVersion: 0.4.0
+version: 0.7.0
+appVersion: 0.5.0
 keywords:
   - ngrok
   - networking

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -12,8 +12,8 @@ Should match all-options snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
-        app.kubernetes.io/version: 0.4.0
-        helm.sh/chart: kubernetes-ingress-controller-0.6.1
+        app.kubernetes.io/version: 0.5.0
+        helm.sh/chart: kubernetes-ingress-controller-0.7.0
       name: RELEASE-NAME-kubernetes-ingress-controller-manager
       namespace: NAMESPACE
     spec:
@@ -65,7 +65,7 @@ Should match all-options snapshot:
                 value: test-value
             - name: TEST_ENV_VAR
               value: test
-            image: docker.io/ngrok/kubernetes-ingress-controller:0.4.0
+            image: docker.io/ngrok/kubernetes-ingress-controller:0.5.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:
@@ -399,8 +399,8 @@ Should match default snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
-        app.kubernetes.io/version: 0.4.0
-        helm.sh/chart: kubernetes-ingress-controller-0.6.1
+        app.kubernetes.io/version: 0.5.0
+        helm.sh/chart: kubernetes-ingress-controller-0.7.0
       name: RELEASE-NAME-kubernetes-ingress-controller-manager
       namespace: NAMESPACE
     spec:
@@ -445,7 +445,7 @@ Should match default snapshot:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: docker.io/ngrok/kubernetes-ingress-controller:0.4.0
+            image: docker.io/ngrok/kubernetes-ingress-controller:0.5.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
@@ -9,7 +9,7 @@ Should match the snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
-        app.kubernetes.io/version: 0.4.0
-        helm.sh/chart: kubernetes-ingress-controller-0.6.1
+        app.kubernetes.io/version: 0.5.0
+        helm.sh/chart: kubernetes-ingress-controller-0.7.0
       name: test-release-kubernetes-ingress-controller
       namespace: test-namespace

--- a/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -9,8 +9,8 @@ Should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
-        app.kubernetes.io/version: 0.4.0
-        helm.sh/chart: kubernetes-ingress-controller-0.6.1
+        app.kubernetes.io/version: 0.5.0
+        helm.sh/chart: kubernetes-ingress-controller-0.7.0
       name: ngrok
     spec:
       controller: k8s.ngrok.com/ingress-controller


### PR DESCRIPTION
## What

Cut new release of the helm chart.

## Breaking Changes
:warning: Yes. The annotation system for configuring Ingresses has been substantially changed since 0.4.0 to use `NgrokModuleSet` Custom Resources instead of individual annotations.
