### PR TITLE
Alex/fix default container name

### DIFF
--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: manager
+        kubectl.kubernetes.io/default-container: ngrok-ingress-controller
         {{- if .Values.podAnnotations }}
           {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -18,7 +18,6 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: ngrok-ingress-controller
         {{- if .Values.podAnnotations }}
           {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -26,7 +26,7 @@ Should match all-options snapshot:
       template:
         metadata:
           annotations:
-            kubectl.kubernetes.io/default-container: manager
+            kubectl.kubernetes.io/default-container: ngrok-ingress-controller
             prometheus.io/path: /metrics
             prometheus.io/port: "8080"
             prometheus.io/scrape: "true"
@@ -413,7 +413,7 @@ Should match default snapshot:
       template:
         metadata:
           annotations:
-            kubectl.kubernetes.io/default-container: manager
+            kubectl.kubernetes.io/default-container: ngrok-ingress-controller
             prometheus.io/path: /metrics
             prometheus.io/port: "8080"
             prometheus.io/scrape: "true"

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -26,7 +26,6 @@ Should match all-options snapshot:
       template:
         metadata:
           annotations:
-            kubectl.kubernetes.io/default-container: ngrok-ingress-controller
             prometheus.io/path: /metrics
             prometheus.io/port: "8080"
             prometheus.io/scrape: "true"
@@ -413,7 +412,6 @@ Should match default snapshot:
       template:
         metadata:
           annotations:
-            kubectl.kubernetes.io/default-container: ngrok-ingress-controller
             prometheus.io/path: /metrics
             prometheus.io/port: "8080"
             prometheus.io/scrape: "true"


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #178

## What
We used to have multiple containers and one used to be called `manager` as the default from kubebuiler. We've since gotten rid of the sidecar ngrok agent container and renamed our main container.

```
k logs ngrok-ingress-controller-kubernetes-ingress-controller-man7kd8g -f
Default container name "manager" not found in pod ngrok-ingress-controller-kubernetes-ingress-controller-man7kd8g
Defaulted container "ngrok-ingress-controller" out of: ngrok-ingress-controller, consul-dataplane, consul-connect-inject-init (init)
```

## How
Rather than changing the default container name to our new container name, this just removes the field since we only have 1 container now. 

## Breaking Changes
none
