### PR TITLE
Include ngrok controller version in user agent

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,19 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore all files then explicitly whitelist ones we want
 *
+# Copy in the Makefile to re-use build command
+!Makefile
+# Used to inject version build info
+!VERSION
+# Used to inject git commit build info
+!.git/
+# Code
 !api/
+!cmd/
+!hack/
 !internal/
 !pkg/
-!cmd/
+!scripts/
 !**/*.go
 !**/*.mod
 !**/*.sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,18 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY internal/ internal/
-COPY pkg/ pkg/
+COPY . .
 
 ARG TARGETOS TARGETARCH
+
 # Build
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" make _build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM --platform=${TARGETPLATFORM:-linux/amd64} gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ IMG ?= kubernetes-ingress-controller
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 
+REPO_URL = github.com/ngrok/kubernetes-ingress-controller
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -16,6 +18,9 @@ endif
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
+
+GIT_COMMIT = $(shell git rev-parse HEAD)
+VERSION = $(shell cat VERSION)
 
 # Tools
 
@@ -75,8 +80,13 @@ test: manifests generate fmt vet ## Run tests.
 ##@ Build
 
 .PHONY: build
-build: preflight generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+build: preflight generate fmt vet _build ## Build manager binary.
+
+.PHONY: _build
+_build:
+	go build -o bin/manager -trimpath -ldflags "-s -w \
+		-X $(REPO_URL)/internal/version.gitCommit=$(GIT_COMMIT) \
+		-X $(REPO_URL)/internal/version.version=$(VERSION)" main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,45 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	// version of the ngrok kubernetes-ingress-controller.
+	// Injected at build time via LDFlags.
+	version = "0.0.0"
+
+	// gitCommit is the git sha1
+	// Injected at build time via LDFlags.
+	gitCommit = ""
+)
+
+// BuildInfo describes the compile time information.
+type BuildInfo struct {
+	// Version is the current semver.
+	Version string `json:"version,omitempty"`
+	// GitCommit is the git sha1.
+	GitCommit string `json:"git_commit,omitempty"`
+	// GoVersion is the version of the Go compiler used.
+	GoVersion string `json:"go_version,omitempty"`
+}
+
+// GetVersion returns the semver string of the version
+func GetVersion() string {
+	return version
+}
+
+// GetUserAgent returns a user agent to use
+func GetUserAgent() string {
+	return fmt.Sprintf("ngrok-ingress-controller/%s", GetVersion())
+}
+
+// Get returns build info
+func Get() BuildInfo {
+	return BuildInfo{
+		Version:   GetVersion(),
+		GitCommit: gitCommit,
+		GoVersion: runtime.Version(),
+	}
+}

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ngrok/kubernetes-ingress-controller/internal/controllers"
 	"github.com/ngrok/kubernetes-ingress-controller/internal/ngrokapi"
 	"github.com/ngrok/kubernetes-ingress-controller/internal/store"
+	"github.com/ngrok/kubernetes-ingress-controller/internal/version"
 	"github.com/ngrok/kubernetes-ingress-controller/pkg/tunneldriver"
 	//+kubebuilder:scaffold:imports
 )
@@ -127,8 +128,11 @@ func runController(ctx context.Context, opts managerOpts) error {
 		return errors.New("NGROK_API_KEY environment variable should be set, but was not")
 	}
 
+	buildInfo := version.Get()
+	setupLog.Info("starting manager", "version", buildInfo.Version, "commit", buildInfo.GitCommit)
+
 	clientConfigOpts := []ngrok.ClientConfigOption{
-		ngrok.WithUserAgent("ngrok-ingress-controller/0.5.0"),
+		ngrok.WithUserAgent(version.GetUserAgent()),
 	}
 
 	ngrokClientConfig := ngrok.NewClientConfig(opts.ngrokAPIKey, clientConfigOpts...)


### PR DESCRIPTION
Resolves #188 

## What

Includes the ingress controller version in the `useragent` string. Also prints out the build info when the controller starts.

## How

Pass build info variables to the linker when building the go binary.  Had to change the `.dockerignore` in order to get the `.git` directory, `VERSION`, `Makefile`, and a few others into the docker context so they could be added in the image during the build.

## Breaking Changes

No