### PR TITLE
Add log level configuration to helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,9 @@ deploy: docker-build manifests kustomize ## Deploy controller to the K8s cluster
 		--set image.repository=$(IMG) \
 		--set credentials.apiKey=$(NGROK_API_KEY) \
 		--set credentials.authtoken=$(NGROK_AUTHTOKEN) \
+		--set log.format=console \
+		--set log.level=debug \
+		--set log.stacktraceLevel=panic \
 		--set metaData.env=local,metaData.from=makefile && \
 	kubectl rollout restart deployment ngrok-ingress-controller-kubernetes-ingress-controller-manager -n ngrok-ingress-controller
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/onsi/gomega v1.26.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
-	go.uber.org/zap v1.24.0
 	golang.ngrok.com/ngrok v0.0.0-20230105184634-66ddd48add80
 	golang.org/x/sync v0.1.0
 	k8s.io/api v0.26.0
@@ -79,6 +78,7 @@ require (
 	go.starlark.net v0.0.0-20230103143115-09991d3a103e // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
+	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.4.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.5.0 // indirect

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -73,4 +73,8 @@ To uninstall the chart:
 | `serviceAccount.create`      | Specifies whether a ServiceAccount should be created                                                                  | `true`                                |
 | `serviceAccount.name`        | The name of the ServiceAccount to use.                                                                                | `""`                                  |
 | `serviceAccount.annotations` | Additional annotations to add to the ServiceAccount                                                                   | `{}`                                  |
+| `log.level`                  | The level to log at. One of 'debug', 'info', or 'error'.                                                              | `""`                                  |
+| `log.stacktraceLevel`        | The level to report stacktrace logs one of 'info' or 'error'.                                                         | `""`                                  |
+| `log.format`                 | The log format to use. One of console, json.                                                                          | `""`                                  |
+| `log.developmentMode`        | If true, enables development mode in the underlying zap logger.                                                       | `false`                               |
 

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -73,8 +73,7 @@ To uninstall the chart:
 | `serviceAccount.create`      | Specifies whether a ServiceAccount should be created                                                                  | `true`                                |
 | `serviceAccount.name`        | The name of the ServiceAccount to use.                                                                                | `""`                                  |
 | `serviceAccount.annotations` | Additional annotations to add to the ServiceAccount                                                                   | `{}`                                  |
-| `log.level`                  | The level to log at. One of 'debug', 'info', or 'error'.                                                              | `""`                                  |
-| `log.stacktraceLevel`        | The level to report stacktrace logs one of 'info' or 'error'.                                                         | `""`                                  |
-| `log.format`                 | The log format to use. One of console, json.                                                                          | `""`                                  |
-| `log.developmentMode`        | If true, enables development mode in the underlying zap logger.                                                       | `false`                               |
+| `log.level`                  | The level to log at. One of 'debug', 'info', or 'error'.                                                              | `info`                                |
+| `log.stacktraceLevel`        | The level to report stacktrace logs one of 'info' or 'error'.                                                         | `error`                               |
+| `log.format`                 | The log format to use. One of console, json.                                                                          | `json`                                |
 

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -58,18 +58,9 @@ spec:
         {{- if .Values.watchNamespace }}
         - --watch-namespace={{ .Values.watchNamespace}}
         {{- end }}
-        {{- if .Values.log.level }}
         - --zap-log-level={{ .Values.log.level }}
-        {{- end }}
-        {{- if .Values.log.stacktraceLevel }}
         - --zap-stacktrace-level={{ .Values.log.stacktraceLevel }}
-        {{- end }}
-        {{- if .Values.log.format }}
         - --zap-encoder={{ .Values.log.format }}
-        {{- end }}
-        {{- if .Values.log.developmentMode }}
-        - --zap-devel={{ .Values.log.developmentMode }}
-        {{- end }}
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --election-id={{ include "kubernetes-ingress-controller.fullname" . }}-leader

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -58,6 +58,18 @@ spec:
         {{- if .Values.watchNamespace }}
         - --watch-namespace={{ .Values.watchNamespace}}
         {{- end }}
+        {{- if .Values.log.level }}
+        - --zap-log-level={{ .Values.log.level }}
+        {{- end }}
+        {{- if .Values.log.stacktraceLevel }}
+        - --zap-stacktrace-level={{ .Values.log.stacktraceLevel }}
+        {{- end }}
+        {{- if .Values.log.format }}
+        - --zap-encoder={{ .Values.log.format }}
+        {{- end }}
+        {{- if .Values.log.developmentMode }}
+        - --zap-devel={{ .Values.log.developmentMode }}
+        {{- end }}
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --election-id={{ include "kubernetes-ingress-controller.fullname" . }}-leader

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -38,6 +38,9 @@ Should match all-options snapshot:
           containers:
           - args:
             - --controller-name=k8s.ngrok.com/ingress-controller
+            - --zap-log-level=info
+            - --zap-stacktrace-level=error
+            - --zap-encoder=json
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8080
             - --election-id=RELEASE-NAME-kubernetes-ingress-controller-leader
@@ -425,6 +428,9 @@ Should match default snapshot:
           containers:
           - args:
             - --controller-name=k8s.ngrok.com/ingress-controller
+            - --zap-log-level=info
+            - --zap-stacktrace-level=error
+            - --zap-encoder=json
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8080
             - --election-id=RELEASE-NAME-kubernetes-ingress-controller-leader

--- a/helm/ingress-controller/tests/controller-deployment_test.yaml
+++ b/helm/ingress-controller/tests/controller-deployment_test.yaml
@@ -85,3 +85,43 @@ tests:
   - matchRegex:
       path: spec.template.spec.containers[0].volumeMounts[0].mountPath
       pattern: /test-volume
+- it: Should pass log level argument if set
+  set:
+    log:
+      level: error
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --zap-log-level=error
+- it: Should pass log format argument if set
+  set:
+    log:
+      format: console
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --zap-encoder=console
+- it: Should pass stacktrace log level argument if set
+  set:
+    log:
+      stacktraceLevel: error
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --zap-stacktrace-level=error
+- it: Should pass log development mode argument if set
+  set:
+    log:
+      developmentMode: true
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].args
+      content: --zap-devel=true

--- a/helm/ingress-controller/tests/controller-deployment_test.yaml
+++ b/helm/ingress-controller/tests/controller-deployment_test.yaml
@@ -115,13 +115,3 @@ tests:
   - contains:
       path: spec.template.spec.containers[0].args
       content: --zap-stacktrace-level=error
-- it: Should pass log development mode argument if set
-  set:
-    log:
-      developmentMode: true
-  template: controller-deployment.yaml
-  documentIndex: 0 # Document 0 is the deployment since its the first template
-  asserts:
-  - contains:
-      path: spec.template.spec.containers[0].args
-      content: --zap-devel=true

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -130,3 +130,15 @@ serviceAccount:
   create: true
   name: ""
   annotations: {}
+
+
+## Logging configuration
+## @param log.level The level to log at. One of 'debug', 'info', or 'error'.
+## @param log.stacktraceLevel The level to report stacktrace logs one of 'info' or 'error'.
+## @param log.format The log format to use. One of console, json.
+## @param log.developmentMode If true, enables development mode in the underlying zap logger.
+log:
+  level: ""
+  stacktraceLevel: ""
+  format: ""
+  developmentMode: false

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -136,9 +136,7 @@ serviceAccount:
 ## @param log.level The level to log at. One of 'debug', 'info', or 'error'.
 ## @param log.stacktraceLevel The level to report stacktrace logs one of 'info' or 'error'.
 ## @param log.format The log format to use. One of console, json.
-## @param log.developmentMode If true, enables development mode in the underlying zap logger.
 log:
-  level: ""
-  stacktraceLevel: ""
-  format: ""
-  developmentMode: false
+  format: json
+  level: info
+  stacktraceLevel: error

--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 
-	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/spf13/cobra"
@@ -105,7 +104,7 @@ func cmd() *cobra.Command {
 	c.Flags().StringVar(&opts.serverAddr, "server-addr", "", "The address of the ngrok server to use for tunnels")
 	c.Flags().StringVar(&opts.controllerName, "controller-name", "k8s.ngrok.com/ingress-controller", "The name of the controller to use for matching ingresses classes")
 	c.Flags().StringVar(&opts.watchNamespace, "watch-namespace", "", "Namespace to watch for Kubernetes resources. Defaults to all namespaces.")
-	opts.zapOpts = &zap.Options{Development: true, StacktraceLevel: zapcore.DPanicLevel}
+	opts.zapOpts = &zap.Options{}
 	goFlagSet := flag.NewFlagSet("manager", flag.ContinueOnError)
 	opts.zapOpts.BindFlags(goFlagSet)
 	c.Flags().AddGoFlagSet(goFlagSet)


### PR DESCRIPTION
resolves: #144 

## What

Allows configuring the controller log levels via helm chart values.

## How

Removes the default set in `main.go` of being in `development` mode, back to `zap` defaults. Adds new config values to the helm chart's `values.yaml` for setting different log configuration values.

For development, setting the following overrides should provide the same log behavior as before.

```yaml

log:
  format: console
  level: debug
  stacktraceLevel: panic

```

## Breaking Changes

Yes, to default log level and output. 
