### PR TITLE
Don't log errors on normal connection closing

### DIFF
--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -3,6 +3,7 @@ package tunneldriver
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net"
@@ -179,11 +180,12 @@ func handleConnections(ctx context.Context, dialer Dialer, tun ngrok.Tunnel, des
 		go func() {
 			ctx := log.IntoContext(ctx, connLogger)
 			err := handleConn(ctx, dest, dialer, conn)
-			if err != nil {
-				logger.Error(err, "Error handling connection")
-			} else {
-				logger.Info("Connection handled")
+			if err == nil || errors.Is(err, net.ErrClosed) {
+				connLogger.Info("Connection closed")
+				return
 			}
+
+			connLogger.Error(err, "Error handling connection")
 		}()
 	}
 }


### PR DESCRIPTION
## What

Small logging fix. Previously we'd have error logs for connections being closed when one of the 2 go routine's connections was closed under normal circumstances. This isn't really an error and we should log these normal connection closings with info level.

## How

If the error is `nil` or a is a `net.ErrClosed` error, just log the normal connection closed

## Breaking Changes

No
