### PR TITLE
Fix docs ingress

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,9 +54,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example-ingress
-  annotations:
-    kubernetes.io/ingress.class: "ngrok"
 spec:
+  ingressClassName: ngrok
   rules:
   - host: example.com
     http:


### PR DESCRIPTION
the ingress controller uses the ingress class stable version spec `ingressClassName` and not the old annotation syntax

