### PR TITLE
fix: remove note about alpha and pro account

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ For a comprehensive, step-by-step quick start, check our [get started guide in n
 ## Known Limitations
 
 1. This project is currently in beta as we continue testing and receiving feedback. The functionality and CRD contracts may change. It is currently used internally at ngrok for providing ingress to some of our production workloads.
-1. As of today, the ngrok Ingress Controller works only on ngrok accounts with the Pro subscription or above. If you would like to use the ngrok Ingress Controller with a free ngrok account, please [reach us out in our slack community](https://ngrok.com/slack) and we will be happy to help.
 
 ## Support
 

--- a/docs/developer-guide/releasing.md
+++ b/docs/developer-guide/releasing.md
@@ -30,7 +30,7 @@ and can be installed by following the instructions in the chart's [README](../he
 ## Semantic Versioning
 
 This project uses [semantic versioning](https://semver.org/) for both the the docker image
-and helm chart. Please note that this project is still under development(pre 1.0.0) and considered `alpha` status at this time.
+and helm chart.
 
 From the [semver spec](https://semver.org/#spec-item-4):
 

--- a/helm/ingress-controller/templates/NOTES.txt
+++ b/helm/ingress-controller/templates/NOTES.txt
@@ -50,5 +50,4 @@ available on the public internet at "https://{{ $service.metadata.name -}}-{{- $
 Once done, view your edges in the Dashboard https://dashboard.ngrok.com/cloud-edge/edges
 Find the tunnels running in your cluster here https://dashboard.ngrok.com/tunnels/agents
 
-This controller is under active development and is in Alpha. It is not suggested to use this in production.
 If you have any questions or feedback, please join us in https://ngrok.com/slack and let us know!


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
This change removes the comment about this project being in alpha from the notes section. It also removes the note about a pro account since it is no longer required.

## How
Removing the incorrect text

## Breaking Changes
No