### PR TITLE
Make subdomain replaceable with env variable

### DIFF
--- a/docs/examples/hello-world/manifests.yaml
+++ b/docs/examples/hello-world/manifests.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ingressClassName: ngrok
   rules:
-    - host: ${SUBDOMAIN}.ngrok.io
+    - host: ${NGROK_SUBDOMAIN}.ngrok.io
       http:
         paths:
           - path: /

--- a/docs/examples/hello-world/manifests.yaml
+++ b/docs/examples/hello-world/manifests.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ingressClassName: ngrok
   rules:
-    - host: $SUBDOMAIN-game-2048.ngrok.io
+    - host: ${SUBDOMAIN}.ngrok.io
       http:
         paths:
           - path: /


### PR DESCRIPTION
## What

This makes the manifest.yaml applicable with environment variables and the 

## How

Example:

```bash
export SUBDOMAIN="subdomain-name"
wget https://raw.githubusercontent.com/sudobinbash/kubernetes-ingress-controller/frederico/get-started-tweak/docs/examples/hello-world/manifests.yaml -O - | envsubst | kubectl apply -f -
```

This will replace `${SUBDOMAIN}.ngrok.io` with `subdomain-name.ngrok.io`
