### PR TITLE
fix: Add support for named service ports in Ingress Backend Services

### DIFF
--- a/helm/ingress-controller/templates/rbac/role.yaml
+++ b/helm/ingress-controller/templates/rbac/role.yaml
@@ -32,6 +32,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ingress.k8s.ngrok.com
   resources:
   - domains

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -4,7 +4,7 @@ Should match all-options snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/controller-role: 74105e85ac7febec1e0b93ea36e9a482cf4c17508862b57605a5cea0619f3c1b
+        checksum/controller-role: 55beaaec6ab70343a40b69e51ce45a3c7a1e4c6c48053390666d585b2f0f3458
         checksum/rbac: d31fdcb337a6f1ee71323040c2cbc4d5580d73ae5f7623cd19be57db97f748c1
       labels:
         app.kubernetes.io/component: controller
@@ -224,6 +224,14 @@ Should match all-options snapshot:
       - list
       - watch
     - apiGroups:
+      - ""
+      resources:
+      - services
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
       - ingress.k8s.ngrok.com
       resources:
       - domains
@@ -393,7 +401,7 @@ Should match default snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/controller-role: 74105e85ac7febec1e0b93ea36e9a482cf4c17508862b57605a5cea0619f3c1b
+        checksum/controller-role: 55beaaec6ab70343a40b69e51ce45a3c7a1e4c6c48053390666d585b2f0f3458
         checksum/rbac: d31fdcb337a6f1ee71323040c2cbc4d5580d73ae5f7623cd19be57db97f748c1
       labels:
         app.kubernetes.io/component: controller
@@ -595,6 +603,14 @@ Should match default snapshot:
       - ""
       resources:
       - secrets
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - services
       verbs:
       - get
       - list

--- a/internal/controllers/ingress_controller.go
+++ b/internal/controllers/ingress_controller.go
@@ -51,11 +51,12 @@ func (irec *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses/status,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=ingressclasses,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=ingress.k8s.ngrok.com,resources=ngrokmodulesets,verbs=get;list;watch
 
 // This reconcile function is called by the controller-runtime manager.

--- a/internal/controllers/ingress_controller.go
+++ b/internal/controllers/ingress_controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ngrok/kubernetes-ingress-controller/internal/annotations"
 	internalerrors "github.com/ngrok/kubernetes-ingress-controller/internal/errors"
 	"github.com/ngrok/kubernetes-ingress-controller/internal/store"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -32,6 +33,7 @@ type IngressReconciler struct {
 func (irec *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	storedResources := []client.Object{
 		&netv1.IngressClass{},
+		&corev1.Service{},
 		&ingressv1alpha1.Domain{},
 		&ingressv1alpha1.HTTPSEdge{},
 		&ingressv1alpha1.Tunnel{},

--- a/internal/store/cachestores.go
+++ b/internal/store/cachestores.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-logr/logr"
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -31,6 +32,7 @@ type CacheStores struct {
 	// Core Kubernetes Stores
 	IngressV1      cache.Store
 	IngressClassV1 cache.Store
+	ServiceV1      cache.Store
 
 	// Ngrok Stores
 	DomainV1      cache.Store
@@ -47,6 +49,7 @@ func NewCacheStores(logger logr.Logger) CacheStores {
 	return CacheStores{
 		IngressV1:      cache.NewStore(keyFunc),
 		IngressClassV1: cache.NewStore(clusterResourceKeyFunc),
+		ServiceV1:      cache.NewStore(keyFunc),
 		DomainV1:       cache.NewStore(keyFunc),
 		TunnelV1:       cache.NewStore(keyFunc),
 		HTTPSEdgeV1:    cache.NewStore(keyFunc),
@@ -86,7 +89,10 @@ func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err
 		return c.IngressV1.Get(obj)
 	case *netv1.IngressClass:
 		return c.IngressClassV1.Get(obj)
-		// ----------------------------------------------------------------------------
+	case *corev1.Service:
+		return c.ServiceV1.Get(obj)
+
+	// ----------------------------------------------------------------------------
 	// Ngrok API Support
 	// ----------------------------------------------------------------------------
 	case *ingressv1alpha1.Domain:
@@ -114,10 +120,12 @@ func (c CacheStores) Add(obj runtime.Object) error {
 	// ----------------------------------------------------------------------------
 	case *netv1.Ingress:
 		return c.IngressV1.Add(obj)
-
 	case *netv1.IngressClass:
 		return c.IngressClassV1.Add(obj)
-		// ----------------------------------------------------------------------------
+	case *corev1.Service:
+		return c.ServiceV1.Add(obj)
+
+	// ----------------------------------------------------------------------------
 	// Ngrok API Support
 	// ----------------------------------------------------------------------------
 	case *ingressv1alpha1.Domain:
@@ -148,7 +156,10 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 		return c.IngressV1.Delete(obj)
 	case *netv1.IngressClass:
 		return c.IngressClassV1.Delete(obj)
-		// ----------------------------------------------------------------------------
+	case *corev1.Service:
+		return c.ServiceV1.Delete(obj)
+
+	// ----------------------------------------------------------------------------
 	// Ngrok API Support
 	// ----------------------------------------------------------------------------
 	case *ingressv1alpha1.Domain:

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -68,6 +69,7 @@ func (d *Driver) WithMetaData(customMetadata map[string]string) *Driver {
 // each calculation will be based on an incomplete state of the world. It currently relies on:
 // - Ingresses
 // - IngressClasses
+// - Services
 // - Secrets
 // - Domains
 // - Edges
@@ -89,6 +91,16 @@ func (d *Driver) Seed(ctx context.Context, c client.Reader) error {
 	}
 	for _, ingClass := range ingressClasses.Items {
 		if err := d.Update(&ingClass); err != nil {
+			return err
+		}
+	}
+
+	services := &corev1.ServiceList{}
+	if err := c.List(ctx, services); err != nil {
+		return err
+	}
+	for _, svc := range services.Items {
+		if err := d.Update(&svc); err != nil {
 			return err
 		}
 	}

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -460,15 +460,16 @@ func (d *Driver) calculateTunnels() []ingressv1alpha1.Tunnel {
 						continue
 					}
 
-					d.log.V(3).Info("Searching service for named port", "service", service.Name, "port", path.Backend.Service.Port.Name)
+					d.log.V(3).Info("Searching service for named port", "namespace", namespace, "service", service.Name, "port.name", path.Backend.Service.Port.Name)
 					for _, port := range service.Spec.Ports {
 						if port.Name == path.Backend.Service.Port.Name {
 							servicePort = port.Port
+							d.log.V(3).Info("Found named port for service", "namespace", namespace, "service", service.Name, "port.name", port.Name, "port.number", port.Port)
 							break
 						}
 					}
 					if servicePort <= 0 {
-						d.log.Error(fmt.Errorf("could not find port for service"), "could not find port for service", "service", serviceName, "port", path.Backend.Service.Port.Name)
+						d.log.Error(fmt.Errorf("could not find port for service"), "could not find port for service", "namespace", namespace, "service", serviceName, "port", path.Backend.Service.Port.Name)
 						// No port, skip creating tunnel for now
 						continue
 					}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,6 +21,7 @@ import (
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/v1alpha1"
 	"github.com/ngrok/kubernetes-ingress-controller/internal/errors"
 
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -38,6 +39,7 @@ type Storer interface {
 
 	GetIngressClassV1(name string) (*netv1.IngressClass, error)
 	GetIngressV1(name, namespace string) (*netv1.Ingress, error)
+	GetServiceV1(name, namespace string) (*corev1.Service, error)
 	GetNgrokIngressV1(name, namespace string) (*netv1.Ingress, error)
 	GetNgrokModuleSetV1(name, namespace string) (*ingressv1alpha1.NgrokModuleSet, error)
 
@@ -117,6 +119,17 @@ func (s Store) GetIngressV1(name, namespcae string) (*netv1.Ingress, error) {
 		return nil, errors.NewErrorNotFound(fmt.Sprintf("Ingress %v not found", name))
 	}
 	return p.(*netv1.Ingress), nil
+}
+
+func (s Store) GetServiceV1(name, namespace string) (*corev1.Service, error) {
+	p, exists, err := s.stores.ServiceV1.GetByKey(getKey(name, namespace))
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewErrorNotFound(fmt.Sprintf("Service %v not found", name))
+	}
+	return p.(*corev1.Service), nil
 }
 
 // GetNgrokIngressV1 looks up the Ingress resource by name and namespace and returns it if it's found

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -70,6 +70,27 @@ var _ = Describe("Store", func() {
 		})
 	})
 
+	var _ = Describe("GetServiceV1", func() {
+		Context("when the service exists", func() {
+			BeforeEach(func() {
+				svc := NewTestServiceV1("test-service", "test-namespace")
+				store.Add(&svc)
+			})
+			It("returns the service", func() {
+				svc, err := store.GetServiceV1("test-service", "test-namespace")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(svc.Name).To(Equal("test-service"))
+			})
+		})
+		Context("when the service does not exist", func() {
+			It("returns an error", func() {
+				svc, err := store.GetServiceV1("does-not-exist", "does-not-exist")
+				Expect(err).To(HaveOccurred())
+				Expect(svc).To(BeNil())
+			})
+		})
+	})
+
 	var _ = Describe("GetNgrokIngressV1", func() {
 		Context("when the ngrok ingress exists", func() {
 			BeforeEach(func() {

--- a/internal/store/testutility.go
+++ b/internal/store/testutility.go
@@ -2,8 +2,10 @@ package store
 
 import (
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func NewTestIngressClass(name string, isDefault bool, isNgrok bool) netv1.IngressClass {
@@ -64,6 +66,25 @@ func NewTestIngressV1(name string, namespace string) netv1.Ingress {
 							},
 						},
 					},
+				},
+			},
+		},
+	}
+}
+
+func NewTestServiceV1(name string, namespace string) corev1.Service {
+	return corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Protocol:   "TCP",
+					Port:       80,
+					TargetPort: intstr.FromString("http"),
 				},
 			},
 		},


### PR DESCRIPTION
Closes #220 

## What

Fixes backend ports specified by `name` in Ingress Backend Service definitions not working and defaulting to `0`. You can now specify the port by `name` as one would expect. Ex:

```yaml
spec:
  ingressClassName: ngrok
  rules:
  - host: my-test-app-1.ngrok.io
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: test-app-1
            port:
              name: http # Fixed this not working
```


## How

* Added support for `v1.Service` to the cachestore and driver
* Initially seed the driver's store with `v1.Service`s on start
* Modified the permissions of the controller to `get/list/watch` `v1.Service`
* Check if the port number on the ingress rule's backend service is `<= 0`. If it is, then we look up the service by its name and try to find a port with a matching name and use the port defined on it.

## Breaking Changes

No
