### PR TITLE
:tada: Cut Helm chart 0.9.0 release :tada:

### DIFF
--- a/helm/ingress-controller/CHANGELOG.md
+++ b/helm/ingress-controller/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.0
+### Added
+- Add a 'podLabels' option to the helm chart [#212](https://github.com/ngrok/kubernetes-ingress-controller/pull/212).
+- Permission to `get`,`list`, and `watch` `services` [#222](https://github.com/ngrok-kubernetes-ingress-controller/pull/222).
+
 ## 0.8.0
 ### Changed
 - Log Level configuration to helm chart [#199](https://github.com/ngrok/kubernetes-ingress-controller/pull/199).

--- a/helm/ingress-controller/Chart.yaml
+++ b/helm/ingress-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: kubernetes-ingress-controller
 description: A Kubernetes ingress controller built using ngrok.
-version: 0.8.0
-appVersion: 0.6.0
+version: 0.9.0
+appVersion: 0.7.0
 keywords:
   - ngrok
   - networking

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -12,8 +12,8 @@ Should match all-options snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
-        app.kubernetes.io/version: 0.6.0
-        helm.sh/chart: kubernetes-ingress-controller-0.8.0
+        app.kubernetes.io/version: 0.7.0
+        helm.sh/chart: kubernetes-ingress-controller-0.9.0
       name: RELEASE-NAME-kubernetes-ingress-controller-manager
       namespace: NAMESPACE
     spec:
@@ -67,7 +67,7 @@ Should match all-options snapshot:
                 value: test-value
             - name: TEST_ENV_VAR
               value: test
-            image: docker.io/ngrok/kubernetes-ingress-controller:0.6.0
+            image: docker.io/ngrok/kubernetes-ingress-controller:0.7.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:
@@ -409,8 +409,8 @@ Should match default snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
-        app.kubernetes.io/version: 0.6.0
-        helm.sh/chart: kubernetes-ingress-controller-0.8.0
+        app.kubernetes.io/version: 0.7.0
+        helm.sh/chart: kubernetes-ingress-controller-0.9.0
       name: RELEASE-NAME-kubernetes-ingress-controller-manager
       namespace: NAMESPACE
     spec:
@@ -457,7 +457,7 @@ Should match default snapshot:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: docker.io/ngrok/kubernetes-ingress-controller:0.6.0
+            image: docker.io/ngrok/kubernetes-ingress-controller:0.7.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
@@ -9,7 +9,7 @@ Should match the snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
-        app.kubernetes.io/version: 0.6.0
-        helm.sh/chart: kubernetes-ingress-controller-0.8.0
+        app.kubernetes.io/version: 0.7.0
+        helm.sh/chart: kubernetes-ingress-controller-0.9.0
       name: test-release-kubernetes-ingress-controller
       namespace: test-namespace

--- a/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -9,8 +9,8 @@ Should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
-        app.kubernetes.io/version: 0.6.0
-        helm.sh/chart: kubernetes-ingress-controller-0.8.0
+        app.kubernetes.io/version: 0.7.0
+        helm.sh/chart: kubernetes-ingress-controller-0.9.0
       name: ngrok
     spec:
       controller: k8s.ngrok.com/ingress-controller


### PR DESCRIPTION
## What

Releases version `0.9.0` of the helm-chart. Defaults the controller image version to `0.7.0`

## Breaking Changes

No
