### PR TITLE
Some updates to handle different cases for e2e run

### DIFF
--- a/docs/developer-guide/README.md
+++ b/docs/developer-guide/README.md
@@ -38,7 +38,7 @@ Several examples are provided in the [`e2e-fixtures` folder](https://github.com/
 Then, you need to update the `value` field in that new file.
 
 You can then apply the given example via `kubectl apply -k e2e-fixtures/<example in question>`, i.e.
-`kubectl apply -k e2e-fixtures/hello-world-ingess`.
+`kubectl apply -k e2e-fixtures/hello-world-ingress`.
 
 ### E2E Tests
 

--- a/e2e-fixtures/hello-world-ingress/EXAMPLE-config-pt2.yaml
+++ b/e2e-fixtures/hello-world-ingress/EXAMPLE-config-pt2.yaml
@@ -3,6 +3,3 @@
 - op: replace
   path: /spec/rules/0/host
   value: <UNIQUE SUBDOMAIN>.ngrok.io
-- op: replace
-  path: /spec/rules/1/host
-  value: <UNIQUE SUBDOMAIN>.ngrok.io

--- a/e2e-fixtures/hello-world-ingress/hello-world-ingress.yaml
+++ b/e2e-fixtures/hello-world-ingress/hello-world-ingress.yaml
@@ -28,7 +28,7 @@ spec:
             name: nginx
             port:
               number: 80
-  - host: bezek-hello-world-ingress-2.ngrok.io
+  - host: SET-VIA-config.yaml
     http:
       paths:
       - path: /test
@@ -59,7 +59,7 @@ metadata:
 spec:
   ingressClassName: ngrok
   rules:
-  - host: bezek-hello-world-ingress-2.ngrok.io
+  - host: SET-VIA-config.yaml
     http:
       paths:
       - path: /second

--- a/e2e-fixtures/hello-world-ingress/kustomization.yaml
+++ b/e2e-fixtures/hello-world-ingress/kustomization.yaml
@@ -8,3 +8,9 @@ patchesJson6902:
     kind: Ingress
     name: minimal-ingress
   path: config.yaml
+- target:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+    name: minimal-ingress-pt2
+  path: config-pt2.yaml

--- a/e2e-fixtures/ingress-class/e2e-expected.yaml
+++ b/e2e-fixtures/ingress-class/e2e-expected.yaml
@@ -3,4 +3,4 @@ config.yaml:
     "/": "HTTP/2 200"
 config-different.yaml:
   paths:
-    "/": "HTTP/1.1 404 Not Found"
+    "/": "HTTP/2 404"

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,8 @@
           go-tools
           golangci-lint
           kubernetes-helm
+          jq
+          yq
         ];
       };
     }));

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -7,8 +7,8 @@ This is the helm chart to install the ngrok ingress controller
 ## Prerequisites
 
 The cluster Must be setup with a secret named `ngrok-ingress-controller-credentials` with the following keys:
-* NGROK\_AUTHTOKEN
-* NGROK\_API\_KEY
+* AUTHTOKEN
+* API\_KEY
 
 ## Install the controller with helm
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -7,6 +7,17 @@ kubectl config set-context --current --namespace=$namespace
 
 # TODO: Use ngrok cli api to delete all edges owned by the ingress controller
 
+echo "~~~ Validating dependencies"
+for prog in jq yq
+do
+  PROGPATH=`which $prog || echo ''`
+  if [ "${PROGPATH:-}" == "" ]
+  then
+    echo "Program '$prog' not found, please install it. Exiting"
+    exit
+  fi
+done
+
 echo "~~~ Cleaning up previous deploy of e2e-fixtures"
 for example in $(ls -d e2e-fixtures/*)
 do
@@ -29,7 +40,7 @@ echo "--- Deploying ngrok-ingress-controller"
 make deploy
 
 echo "--- Deploying e2e-fixtures"
-if [ "$GOOGLE_CLIENT_ID" != "" ]
+if [ "${GOOGLE_CLIENT_ID:-}" != "" ]
 then
   kubectl create secret generic ngrok-corp-ingress-oauth-credentials \
     --from-literal=ClientID=$GOOGLE_CLIENT_ID \
@@ -40,6 +51,7 @@ do
     kubectl apply -k $example || true
 done
 
+echo "--- Waiting for deployment"
 sleep 120
 
 # Run tests


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
Changes that made the e2e tests work for me, these may not be universally applicable, so happy to cherry pick anything that is actually useful.

## How

- Typo in developer guide
- Kustomization changes in `e2e-fixtures/hello-world-ingress` to remove `bezek-hello-world-ingress-2` and set via config
- `e2e-fixtures/ingress-class` 404 is HTTP/2 for me
- The secrets keys don't seem to have `NGROK` prefix, unlike the environment variables they set
- `jq` and `yq` weren't installed on this machine, added to nix config, and added some bash to check for them up front. looks like josh is adding nix support though, so this may become irrelevant.
- Changed the test for `GOOGLE_CLIENT_ID` to not error out if not defined, due to the `set -eu -o pipefail`
- A message before the long sleep to make the lack of output more expected

## Breaking Changes
N/A
