### PR TITLE
Better handle errors encountered while calculating HTTPSEdges

### DIFF
--- a/docs/deployment-guide/white-label-agent-ingress.md
+++ b/docs/deployment-guide/white-label-agent-ingress.md
@@ -2,7 +2,7 @@
 
 If you're running an ngrok and/or ingress controller behind a corporate firewall, you may encounter connectivity issues due to the agent or controller not being able to communicate with the ngrok network edge. If you're facing such issues, you can run the ngrok cli command, which is documented [here](https://ngrok.com/docs/guides/running-behind-firewalls) to diagnose the problem.
 
-However, if opening connectivity is not an option, you can set up a custom ingress domain on your dashboard. This way, you can configure the ingress controller to use the custom domain instead of the default ngrok.io domain.
+However, if opening connectivity is not an option, you can set up a custom ingress domain on your dashboard. This way, you can configure the ingress controller to use the custom domain instead of the default ngrok.app domain.
 
 To get started with this, go to your dashboard and create a custom ingress domain. Once created, you can configure the ingress controller by using the following command:
 

--- a/docs/examples/bad-module-load/manifest.yml
+++ b/docs/examples/bad-module-load/manifest.yml
@@ -1,0 +1,87 @@
+apiVersion: ingress.k8s.ngrok.com/v1alpha1
+kind: IPPolicy
+metadata:
+  name: test-policy
+spec:
+  description: "Deny all policy"
+  rules:
+  - action: "deny"
+    cidr: 0.0.0.0/0
+    description: "Deny all"
+---
+apiVersion: ingress.k8s.ngrok.com/v1alpha1
+kind: NgrokModuleSet
+metadata:
+  name: ip-restrictions
+modules:
+  ipRestriction:
+    policies:
+    - "test-policy-typo"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-1
+spec:
+  ingressClassName: ngrok
+  rules:
+    - host: test-ing1.ngrok.io
+      http:
+        paths:
+          - path: /working
+            pathType: Prefix
+            backend:
+              service:
+                name: svc-1
+                port:
+                  number: 80
+    - host: test-ing2.ngrok.app
+      http:
+        paths:
+          - path: /working
+            pathType: Prefix
+            backend:
+              service:
+                name: svc-2
+                port:
+                  number: 80                  
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-2
+  annotations:
+    k8s.ngrok.com/modules: ip-restrictions-typo
+spec:
+  ingressClassName: ngrok
+  rules:
+    - host: test-ing1.ngrok.app
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: svc-1
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-3
+  annotations:
+    k8s.ngrok.com/modules: ip-restrictions
+spec:
+  ingressClassName: ngrok
+  rules:
+    - host: test-ing2.ngrok.app
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: svc-2
+                port:
+                  number: 80

--- a/docs/examples/bad-module-load/manifest.yml
+++ b/docs/examples/bad-module-load/manifest.yml
@@ -25,7 +25,7 @@ metadata:
 spec:
   ingressClassName: ngrok
   rules:
-    - host: test-ing1.ngrok.io
+    - host: test-ing1.ngrok.app
       http:
         paths:
           - path: /working

--- a/docs/examples/consul/README.md
+++ b/docs/examples/consul/README.md
@@ -103,7 +103,7 @@ metadata:
 spec:
   ingressClassName: ngrok
   rules:
-  - host: YOUR-CUSTOM-SUBDOMAIN-consul-ngrok-demo.ngrok.io
+  - host: YOUR-CUSTOM-SUBDOMAIN-consul-ngrok-demo.ngrok.app
     http:
       paths:
       - path: /
@@ -119,7 +119,7 @@ spec:
 Once applied, your domain should be available almost instantaneously! Open your hostname in a browser and you should see the Consul counter application.
 
 ```bash
-open YOUR-CUSTOM-SUBDOMAIN-consul-ngrok-demo.ngrok.io
+open YOUR-CUSTOM-SUBDOMAIN-consul-ngrok-demo.ngrok.app
 ```
 
 Stay tuned and next week we'll expose the Consul Dashboard protected by google oauth!

--- a/docs/user-guide/custom-domain.md
+++ b/docs/user-guide/custom-domain.md
@@ -40,7 +40,7 @@ For custom domains, the domain resource contains the CNAME target value that nee
 Status:
   loadBalancer:
     ingress:
-      hostname:  12jkh25.cname.ngrok.io
+      hostname:  12jkh25.cname.ngrok.app
 ```
 
 From here you can create the DNS record and everything should work as expected. To automate this fully though, see the [example on integrating with external-dns](../examples/external-dns.md).

--- a/docs/user-guide/route-modules.md
+++ b/docs/user-guide/route-modules.md
@@ -5,29 +5,30 @@ ngrok's Cloud Edge [Modules](https://ngrok.com/docs/cloud-edge/modules/) allow y
 
 <!-- TOC depthfrom:2 -->
 
-- [Design](#design)
+- [Modules](#modules)
+  - [Design](#design)
     - [Reusable](#reusable)
     - [Composable](#composable)
     - [RBAC](#rbac)
-- [Supported Modules](#supported-modules)
+  - [Supported Modules](#supported-modules)
     - [Circuit Breaker](#circuit-breaker)
     - [Compression](#compression)
-        - [Enabled](#enabled)
-        - [Disabled](#disabled)
+      - [Enabled](#enabled)
+      - [Disabled](#disabled)
     - [Headers](#headers)
-        - [Request](#request)
-        - [Response](#response)
+      - [Request](#request)
+      - [Response](#response)
     - [IP Restrictions](#ip-restrictions)
     - [OAuth](#oauth)
-        - [Ngrok Managed OAuth Application](#ngrok-managed-oauth-application)
-            - [Google](#google)
-        - [User Managed OAuth Application](#user-managed-oauth-application)
-            - [Google](#google)
-    - [OpenID Connect OIDC](#openid-connect-oidc)
+      - [Ngrok Managed OAuth Application](#ngrok-managed-oauth-application)
+        - [Google](#google)
+      - [User Managed OAuth Application](#user-managed-oauth-application)
+        - [Google](#google-1)
+    - [OpenID Connect (OIDC)](#openid-connect-oidc)
     - [SAML](#saml)
     - [TLS Termination](#tls-termination)
     - [Webhook Verification](#webhook-verification)
-- [Examples](#examples)
+  - [Examples](#examples)
     - [Configuring Multiple Modules](#configuring-multiple-modules)
 
 <!-- /TOC -->
@@ -457,7 +458,7 @@ metadata:
 spec:
   ingressClassName: ngrok
   rules:
-  - host: <my-host>.ngrok.io
+  - host: <my-host>.ngrok.app
     http:
       paths:
       - path: /

--- a/helm/ingress-controller/templates/NOTES.txt
+++ b/helm/ingress-controller/templates/NOTES.txt
@@ -28,7 +28,7 @@ metadata:
 spec:
   ingressClassName: ngrok
   rules:
-  - host: {{ $service.metadata.name -}}-{{- $randomStr -}}.ngrok.io
+  - host: {{ $service.metadata.name -}}-{{- $randomStr -}}.ngrok.app
     http:
       paths:
       - path: /
@@ -40,7 +40,7 @@ spec:
               number: {{ $portMap.port }}
 --------------------------------------------------------------------------------
 Applying this manifest will make the service {{ $service.metadata.name | quote }}
-available on the public internet at "https://{{ $service.metadata.name -}}-{{- $randomStr -}}.ngrok.io/".
+available on the public internet at "https://{{ $service.metadata.name -}}-{{- $randomStr -}}.ngrok.app/".
         {{- end }}
       {{- end }}
     {{- end }}

--- a/internal/annotations/testutil/ingress.go
+++ b/internal/annotations/testutil/ingress.go
@@ -16,7 +16,7 @@ func NewIngress() *networking.Ingress {
 		Spec: networking.IngressSpec{
 			Rules: []networking.IngressRule{
 				{
-					Host: "test.ngrok.io",
+					Host: "test.ngrok.app",
 					IngressRuleValue: networking.IngressRuleValue{
 						HTTP: &networking.HTTPIngressRuleValue{
 							Paths: []networking.HTTPIngressPath{

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -166,6 +166,7 @@ func (r *HTTPSEdgeReconciler) reconcileEdge(ctx context.Context, edge *ingressv1
 	}
 
 	if err = r.reconcileRoutes(ctx, edge, remoteEdge); err != nil {
+		r.Recorder.Event(edge, v1.EventTypeWarning, "RouteReconcileFailed", err.Error())
 		return err
 	}
 

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -37,11 +37,10 @@ type Driver struct {
 	reentranceFlag        int64
 	bypassReentranceCheck bool
 	customMetadata        string
-	recorder              record.EventRecorder
 }
 
 // NewDriver creates a new driver with a basic logger and cache store setup
-func NewDriver(logger logr.Logger, scheme *runtime.Scheme, controllerName string, recorder record.EventRecorder) *Driver {
+func NewDriver(logger logr.Logger, scheme *runtime.Scheme, controllerName string) *Driver {
 	cacheStores := NewCacheStores(logger)
 	s := New(cacheStores, controllerName, logger)
 	return &Driver{
@@ -49,7 +48,6 @@ func NewDriver(logger logr.Logger, scheme *runtime.Scheme, controllerName string
 		cacheStores: cacheStores,
 		log:         logger,
 		scheme:      scheme,
-		recorder:    recorder,
 	}
 }
 
@@ -394,7 +392,6 @@ func (d *Driver) calculateHTTPSEdges(domains []ingressv1alpha1.Domain) ([]ingres
 			if err != nil {
 				d.log.Error(err, "error getting ngrok moduleset for ingress", "ingress", ingress)
 				module_load_failure = true
-				d.recorder.Event(&edge, corev1.EventTypeWarning, "NgrokModuleLoadFailure", err.Error())
 			}
 
 			// Set edge specific modules

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -382,7 +382,7 @@ func (d *Driver) calculateHTTPSEdges() []ingressv1alpha1.HTTPSEdge {
 			modSet, err := d.getNgrokModuleSetForIngress(ingress)
 			if err != nil {
 				d.log.Error(err, "error getting ngrok moduleset for ingress", "ingress", ingress)
-				continue
+				panic(err)
 			}
 
 			// Set edge specific modules
@@ -420,7 +420,7 @@ func (d *Driver) calculateHTTPSEdges() []ingressv1alpha1.HTTPSEdge {
 						servicePort, err := d.getBackendServicePort(*httpIngressPath.Backend.Service, namespace)
 						if err != nil {
 							d.log.Error(err, "could not find port for service", "namespace", namespace, "service", serviceName)
-							continue
+							panic(err)
 						}
 
 						route := ingressv1alpha1.HTTPSEdgeRouteSpec{

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -15,7 +15,6 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/v1alpha1"

--- a/main.go
+++ b/main.go
@@ -260,7 +260,9 @@ func runController(ctx context.Context, opts managerOpts) error {
 // getDriver returns a new Driver instance that is seeded with the current state of the cluster.
 func getDriver(ctx context.Context, mgr manager.Manager, options managerOpts) (*store.Driver, error) {
 	logger := mgr.GetLogger().WithName("cache-store-driver")
-	d := store.NewDriver(logger, mgr.GetScheme(), options.controllerName)
+	driverEventRecorder := mgr.GetEventRecorderFor("cache-store-driver")
+
+	d := store.NewDriver(logger, mgr.GetScheme(), options.controllerName, driverEventRecorder)
 	if options.metaData != "" {
 		metaData := strings.TrimSuffix(options.metaData, ",")
 		// metadata is a comma separated list of key=value pairs.

--- a/main.go
+++ b/main.go
@@ -260,9 +260,7 @@ func runController(ctx context.Context, opts managerOpts) error {
 // getDriver returns a new Driver instance that is seeded with the current state of the cluster.
 func getDriver(ctx context.Context, mgr manager.Manager, options managerOpts) (*store.Driver, error) {
 	logger := mgr.GetLogger().WithName("cache-store-driver")
-	driverEventRecorder := mgr.GetEventRecorderFor("cache-store-driver")
-
-	d := store.NewDriver(logger, mgr.GetScheme(), options.controllerName, driverEventRecorder)
+	d := store.NewDriver(logger, mgr.GetScheme(), options.controllerName)
 	if options.metaData != "" {
 		metaData := strings.TrimSuffix(options.metaData, ",")
 		// metadata is a comma separated list of key=value pairs.


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Resolves #233 

## What
* Errors weren't caught before when resolving modules for HTTPS edges. They now are caught and prevent corresponding deployments from launching.

## How
* Errors are forwarded to tunnel calculators, which prevent the matching tunnel resources from launching.
* Submits error events when reconciling edges.

## Breaking Changes
N/A

## Validation
1. Run `kubectl apply -f docs/examples/bad-module-load/manifest.yml`
2. Run `kubectl get pods`
3. Dump the logs for the ingress pod. It should be named something like: 
```
kubectl logs ngrok-ingress-controller-kubernetes-ingress-controller-<HASH> -f
```
4. Observe logs for errors stemming from bad module specifications:
![image](https://github.com/ngrok/kubernetes-ingress-controller/assets/11064629/ce2b1405-a76b-4331-9bfd-3499aaa01ebd)
5. Check in dashboard that edges are not created for failed modules:
![image](https://github.com/ngrok/kubernetes-ingress-controller/assets/11064629/9e284622-a5da-4f1e-8f6d-37b7881a4915)


