### PR TITLE
validate ip restriction rules, before creating the route

### DIFF
--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -200,6 +200,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 			if err := routeModuleUpdater.ipPolicyResolver.validateIPPolicyNames(ctx, edge.Namespace, routeSpec.IPRestriction.IPPolicies); err != nil {
 				if apierrors.IsNotFound(err) {
 					r.Recorder.Eventf(edge, v1.EventTypeWarning, "FailedValidate", "Could not validate ip restriction: %v", err)
+					continue
 				}
 
 				return err

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -199,7 +199,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 		if routeSpec.IPRestriction != nil {
 			if err := routeModuleUpdater.ipPolicyResolver.validateIPPolicyNames(ctx, edge.Namespace, routeSpec.IPRestriction.IPPolicies); err != nil {
 				if apierrors.IsNotFound(err) {
-					r.Recorder.Eventf(edge, v1.EventTypeWarning, "Validate", "Could not validate ip restriction: ", err)
+					r.Recorder.Eventf(edge, v1.EventTypeWarning, "FailedValidate", "Could not validate ip restriction: %w", err)
 				}
 
 				return err

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -199,7 +199,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 		if routeSpec.IPRestriction != nil {
 			if err := routeModuleUpdater.ipPolicyResolver.validateIPPolicyNames(ctx, edge.Namespace, routeSpec.IPRestriction.IPPolicies); err != nil {
 				if apierrors.IsNotFound(err) {
-					r.Recorder.Eventf(edge, v1.EventTypeWarning, "FailedValidate", "Could not validate ip restriction: %w", err)
+					r.Recorder.Eventf(edge, v1.EventTypeWarning, "FailedValidate", "Could not validate ip restriction: %v", err)
 				}
 
 				return err

--- a/internal/controllers/utils.go
+++ b/internal/controllers/utils.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
@@ -49,6 +50,21 @@ type ipPolicyResolver struct {
 	client client.Reader
 }
 
+func (r *ipPolicyResolver) validateIPPolicyNames(ctx context.Context, namespace string, namesOrIds []string) error {
+	for _, nameOrId := range namesOrIds {
+		if strings.HasPrefix(nameOrId, "ipp_") && len(nameOrId) == 31 { // TODO better validate
+			// assume this is direct reference to an ngrok object, skip it for now
+			continue
+		}
+
+		policy := new(ingressv1alpha1.IPPolicy)
+		if err := r.client.Get(ctx, types.NamespacedName{Name: nameOrId, Namespace: namespace}, policy); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Resolves and IP policy names or IDs to IDs. If the input is not found, it is assumed to be an ID and is returned as is.
 func (r *ipPolicyResolver) resolveIPPolicyNamesorIds(ctx context.Context, namespace string, namesOrIds []string) ([]string, error) {
 	m := make(map[string]bool)
@@ -58,6 +74,7 @@ func (r *ipPolicyResolver) resolveIPPolicyNamesorIds(ctx context.Context, namesp
 		if err := r.client.Get(ctx, types.NamespacedName{Name: nameOrId, Namespace: namespace}, policy); err != nil {
 			if client.IgnoreNotFound(err) == nil {
 				m[nameOrId] = true // assume it's an ID
+				continue
 			}
 
 			return nil, err // its some other error

--- a/internal/controllers/utils.go
+++ b/internal/controllers/utils.go
@@ -52,8 +52,8 @@ type ipPolicyResolver struct {
 
 func (r *ipPolicyResolver) validateIPPolicyNames(ctx context.Context, namespace string, namesOrIds []string) error {
 	for _, nameOrId := range namesOrIds {
-		if strings.HasPrefix(nameOrId, "ipp_") && len(nameOrId) == 31 { // TODO better validate
-			// assume this is direct reference to an ngrok object, skip it for now
+		if strings.HasPrefix(nameOrId, "ipp_") && len(nameOrId) == 31 {
+			// assume this is direct reference to an ngrok object (e.g. by ID), skip it for now
 			continue
 		}
 


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Fixes: #233 

## What
When the `iprestriction` points to a policy that doesn't exist, we still create the edge, but leave it widely open.

## How
Pre-validate the names. Ignore names that look like ip policy ids (e.g. prefixed with `ipp_`)

## Breaking Changes
The now invalid configs no longer result in an edge route.