### PR TITLE
Initialize route backends after module updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   </a>
 </p>
 
-> _*Warning*_: Currently this project has an issue being tracked [here](https://github.com/ngrok/kubernetes-ingress-controller/issues/208) which can cause the controller to provide ingress to a service even if it failed to configure an authentication module like Oauth on a particular route due to a configuration or intermittent error. Additionally, even when there aren't errors, the controller first sets up ingress and then applies route modules like Oauth immediately after, but there is a brief period where ingress without authentication is provided. This issue is being tracked [here](https://github.com/ngrok/kubernetes-ingress-controller/issues/219). Until this issue is resolved, it's not recommended to use this with security sensitive applications.
+> _*Warning*_: The controller first sets up ingress and then applies route modules like Oauth immediately after, but there is a brief period where ingress without authentication is provided. This issue is being tracked [here](https://github.com/ngrok/kubernetes-ingress-controller/issues/219). Until this issue is resolved, it's not recommended to use this with security sensitive applications.
 
 # ngrok Ingress Controller for Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   </a>
 </p>
 
-> _*Warning*_: The controller first sets up ingress and then applies route modules like Oauth immediately after, but there is a brief period where ingress without authentication is provided. This issue is being tracked [here](https://github.com/ngrok/kubernetes-ingress-controller/issues/219). Until this issue is resolved, it's not recommended to use this with security sensitive applications.
+> _*Warning*_: Currently this project has an issue being tracked [here](https://github.com/ngrok/kubernetes-ingress-controller/issues/208) which can cause the controller to provide ingress to a service even if it failed to configure an authentication module like Oauth on a particular route due to a configuration or intermittent error. Additionally, even when there aren't errors, the controller first sets up ingress and then applies route modules like Oauth immediately after, but there is a brief period where ingress without authentication is provided. This issue is being tracked [here](https://github.com/ngrok/kubernetes-ingress-controller/issues/219). Until this issue is resolved, it's not recommended to use this with security sensitive applications.
 
 # ngrok Ingress Controller for Kubernetes
 

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -188,6 +188,8 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 		secretResolver:   secretResolver{r.Client},
 	}
 
+	edgeRoutes := r.NgrokClientset.HTTPSEdgeRoutes()
+
 	// TODO: clean this up. This is way too much nesting
 	for i, routeSpec := range edge.Spec.Routes {
 		match := r.getMatchingRouteFromEdgeStatus(edge, routeSpec)
@@ -200,7 +202,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 				Match:     routeSpec.Match,
 				MatchType: routeSpec.MatchType,
 			}
-			route, err = r.NgrokClientset.HTTPSEdgeRoutes().Create(ctx, req)
+			route, err = edgeRoutes.Create(ctx, req)
 		} else {
 			// Otherwise, update the current route to disable its backend
 			req := &ngrok.HTTPSEdgeRouteUpdate{
@@ -209,7 +211,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 				Match:     routeSpec.Match,
 				MatchType: routeSpec.MatchType,
 			}
-			route, err = r.NgrokClientset.HTTPSEdgeRoutes().Update(ctx, req)
+			route, err = edgeRoutes.Update(ctx, req)
 		}
 		if err != nil {
 			return err
@@ -246,7 +248,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 				BackendID: backend.ID,
 			},
 		}
-		route, err = r.NgrokClientset.HTTPSEdgeRoutes().Update(ctx, req)
+		route, err = edgeRoutes.Update(ctx, req)
 		if err != nil {
 			return err
 		}
@@ -270,7 +272,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 		}
 		if !found {
 			r.Log.Info("Deleting route", "edgeID", edge.Status.ID, "routeID", remoteRoute.ID)
-			if err := r.NgrokClientset.HTTPSEdgeRoutes().Delete(ctx, &ngrok.EdgeRouteItem{EdgeID: edge.Status.ID, ID: remoteRoute.ID}); err != nil {
+			if err := edgeRoutes.Delete(ctx, &ngrok.EdgeRouteItem{EdgeID: edge.Status.ID, ID: remoteRoute.ID}); err != nil {
 				return err
 			}
 		}

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -209,8 +209,8 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 		var route *ngrok.HTTPSEdgeRoute
 		// Now we go ahead and create the route if it doesn't exist, or find the existing route.
 		// It's important to note here that we are intentionally ommiting the `route.Backend` for new routes, and
-		//  removing it from existing routes. This is because we depend on the route modules being successfully applied
-		//  before we apply the new route. This ensures that any route with a backend is considered to be successfully configured.
+		//  removing it from existing routes. The success or failure of applying a route's modules is then strongly 
+		//  linked the state of its backend. Thus, any route with a backend is considered properly configured.
 		//  See https://github.com/ngrok/kubernetes-ingress-controller/issues/208 for additional context.
 		if match == nil {
 			r.Log.Info("Creating new route", "edgeID", edge.Status.ID, "match", routeSpec.Match, "matchType", routeSpec.MatchType)

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -122,8 +122,8 @@ func (r *HTTPSEdgeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Configuration errors can't be resolved, so don't requeue
 	case errors.IsErrInvalidConfiguration(err):
 		return ctrl.Result{}, nil
+	// No error or is a retryable error, so return as normal
 	default:
-		// No error or is a retryable error, so return as normal
 		return ctrl.Result{}, err
 	}
 }
@@ -264,7 +264,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 		// TODO: Do an entropy check here to avoid unnecessary updates
 		req := &ngrok.HTTPSEdgeRouteUpdate{
 			EdgeID:    edge.Status.ID,
-			ID:        match.ID,
+			ID:        route.ID,
 			Match:     routeSpec.Match,
 			MatchType: routeSpec.MatchType,
 			Backend: &ngrok.EndpointBackendMutate{

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -194,7 +194,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 	// TODO: clean this up. This is way too much nesting
 	for i, routeSpec := range edge.Spec.Routes {
 
-    if routeSpec.IPRestriction != nil {
+		if routeSpec.IPRestriction != nil {
 			if err := routeModuleUpdater.ipPolicyResolver.validateIPPolicyNames(ctx, edge.Namespace, routeSpec.IPRestriction.IPPolicies); err != nil {
 				if apierrors.IsNotFound(err) {
 					r.Recorder.Eventf(edge, v1.EventTypeWarning, "FailedValidate", "Could not validate ip restriction: %v", err)
@@ -204,7 +204,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 				return err
 			}
 		}
-    
+
 		match := r.getMatchingRouteFromEdgeStatus(edge, routeSpec)
 		var route *ngrok.HTTPSEdgeRoute
 		if match == nil {

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -210,7 +210,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 		// Now we go ahead and create the route if it doesn't exist, or find the existing route.
 		// It's important to note here that we are intentionally ommiting the `route.Backend` for new routes, and
 		//  removing it from existing routes. This is because we depend on the route modules being successfully applied
-		//	before we apply the new route. This ensures that any route with a backend is considered to be successfully configured.
+		//  before we apply the new route. This ensures that any route with a backend is considered to be successfully configured.
 		//  See https://github.com/ngrok/kubernetes-ingress-controller/issues/208 for additional context.
 		if match == nil {
 			r.Log.Info("Creating new route", "edgeID", edge.Status.ID, "match", routeSpec.Match, "matchType", routeSpec.MatchType)

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -234,7 +234,6 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 			return err
 		}
 
-		// With the route in hand, we now update its status
 		routeStatuses[i] = ingressv1alpha1.HTTPSEdgeRouteStatus{
 			ID:        route.ID,
 			URI:       route.URI,
@@ -242,7 +241,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 			MatchType: route.MatchType,
 		}
 
-		// With the route now created and backend disabled, we now attempt to apply module updates for a given route
+		// With the route properly staged, we now attempt to apply its module updates
 		r.Log.Info("Updating route modules", "edgeID", edge.Status.ID, "match", routeSpec.Match, "matchType", routeSpec.MatchType)
 		if err := routeModuleUpdater.updateModulesForRoute(ctx, route, &routeSpec); err != nil {
 			r.Recorder.Event(edge, v1.EventTypeWarning, "RouteModuleUpdateFailed", err.Error())

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -139,15 +139,19 @@ func IsErrMissingRequiredSecret(err error) bool {
 }
 
 type ErrInvalidConfiguration struct {
-	message string
+	cause error
 }
 
-func NewErrInvalidConfiguration(cause error) ErrInvalidConfiguration {
-	return ErrInvalidConfiguration{message: cause.Error()}
+func NewErrInvalidConfiguration(cause error) error {
+	return ErrInvalidConfiguration{cause: cause}
 }
 
 func (e ErrInvalidConfiguration) Error() string {
-	return fmt.Sprintf("invalid configuration: %s", e.message)
+	return fmt.Sprintf("invalid configuration: %s", e.cause.Error())
+}
+
+func (e ErrInvalidConfiguration) Unwrap() error {
+	return e.cause
 }
 
 func IsErrorReconcilable(err error) bool {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -155,7 +155,11 @@ func IsErrInvalidConfiguration(err error) bool {
 	return ok
 }
 
-func IsRetryable(err error) bool {
+func IsErrorReconcilable(err error) bool {
+	if err == nil {
+		return true
+	}
+
 	if IsErrInvalidConfiguration(err) {
 		return false
 	}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -135,3 +135,21 @@ func IsErrMissingRequiredSecret(err error) bool {
 	_, ok := err.(ErrMissingRequiredSecret)
 	return ok
 }
+
+type ErrInvalidConfiguration struct {
+	message string
+}
+
+func NewErrInvalidConfiguration(message string) ErrInvalidConfiguration {
+	return ErrInvalidConfiguration{message: message}
+}
+
+func (e ErrInvalidConfiguration) Error() string {
+	return fmt.Sprintf("invalid configuration: %s", e.message)
+}
+
+// IsErrInvalidConfiguration: Reflect: returns true if the error is a ErrInvalidConfiguration
+func IsErrInvalidConfiguration(err error) bool {
+	_, ok := err.(ErrInvalidConfiguration)
+	return ok
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -140,8 +140,8 @@ type ErrInvalidConfiguration struct {
 	message string
 }
 
-func NewErrInvalidConfiguration(message string) ErrInvalidConfiguration {
-	return ErrInvalidConfiguration{message: message}
+func NewErrInvalidConfiguration(cause error) ErrInvalidConfiguration {
+	return ErrInvalidConfiguration{message: cause.Error()}
 }
 
 func (e ErrInvalidConfiguration) Error() string {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ngrok/ngrok-api-go/v5"
 	netv1 "k8s.io/api/networking/v1"
 )
 
@@ -152,4 +153,18 @@ func (e ErrInvalidConfiguration) Error() string {
 func IsErrInvalidConfiguration(err error) bool {
 	_, ok := err.(ErrInvalidConfiguration)
 	return ok
+}
+
+func IsRetryable(err error) bool {
+	if IsErrInvalidConfiguration(err) {
+		return false
+	}
+
+	// Ignore 400 error codes as unretryable
+	codes := make([]int, 0, 100)
+	for i := 400; i <= 500; i++ {
+		codes = append(codes, i)
+	}
+
+	return !ngrok.IsErrorCode(err, codes...)
 }


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Resolves #208

## What
Applying edge routes' backend is now deferred until after route modules are successfully applied. If route modules fail to apply for any reason, the route's backend remains unset, thus closing off access to the edge from that route.

This approach was inspired by [Niji's comment](https://github.com/ngrok/kubernetes-ingress-controller/issues/208#issuecomment-1553703178) in the parent issue.

## How
1. Omit backend from new routes / Remove backend from current routes
2. Route modules now try to apply
2a. If route module application was successful, routes are then updated with their specified backend
2b. If unsuccessful, `reconcileRoutes` returns an error and the route remains backend-less
3. Route statuses are updated

## Breaking Changes
Edge routes will no longer be valid if an error occurs while applying route modules.

## Validation

Given this sample `manifest.yml`:
<details><summary>Expand</summary>
<p>

```yml
kind: NgrokModuleSet
apiVersion: ingress.k8s.ngrok.com/v1alpha1
metadata:
  name: auth
modules:
  oauth:
    google:
      optionsPassthrough: true
      inactivityTimeout: 10m
      maximumDuration: 24h
      authCheckInterval: 20m
      clientSecret:
        name: auth
        key: client-secret
      emailDomains:
      - ngrok.com
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: game-2048
  annotations:
    k8s.ngrok.com/modules: auth
spec:
  ingressClassName: ngrok
  rules:
    - host: test-ingress-12345.ngrok.app
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: game-2048
                port:
                  number: 80
---
apiVersion: v1
kind: Service
metadata:
  name: game-2048
spec:
  ports:
    - name: http
      port: 80
      targetPort: 80
  selector:
    app: game-2048

---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: game-2048
spec:
  replicas: 1
  selector:
    matchLabels:
      app: game-2048
  template:
    metadata:
      labels:
        app: game-2048
    spec:
      containers:
        - name: backend
          image: alexwhen/docker-2048
          ports:
            - name: http
              containerPort: 80
```

</p>
</details> 

### Creating a new route 
1. Apply the manifest `kubectl apply -f manifest.yml`
2. Check the ingress controller pod logs `kubectl logs ngrok-ingress-controller-kubernetes-ingress-controller-<HASH> -f`
4. Observe for error logs / events suggesting a route module application failure
![image](https://github.com/ngrok/kubernetes-ingress-controller/assets/11064629/dd5870ec-c253-49ef-bb03-92ab6c8c93bc)
5. Attempting to hit the route results in an ngrok 6015 error / dashboard error
![image](https://github.com/ngrok/kubernetes-ingress-controller/assets/11064629/da5fa810-db53-429d-956f-10228d7f041d)

![image](https://github.com/ngrok/kubernetes-ingress-controller/assets/11064629/42943e89-5bc7-43a4-bdbf-92779223a5b6)

### Updating a current route
1. Edit the above manifest to remove the `clientSecret` configuration.
2. Re-apply the manifest to create a valid route + backend
![image](https://github.com/ngrok/kubernetes-ingress-controller/assets/11064629/3427d170-2529-4191-9aa0-9df024e490cb)
3. Now undo the edits and attempt to apply a `clientSecret`, like above.
4. This should fail, as there are no secrets loaded into your environment.
5. Observe that backend is still running with the previous (valid) configuration.


## Future Work
* Check for all route prerequisites before attempting any route updates. This would ideally combine with the current `ipPolicies` validation so that we can evaluate other module criteria (such as the correctly set secrets) before executing updates.
* Update this approach to incorporate better wholesale validation before applying updates to minimize downtime. [Niji](https://github.com/ngrok/kubernetes-ingress-controller/pull/243#discussion_r1218499023) captured some theoretical approaches to solving this.