### PR TITLE
Add namespace to secret

### DIFF
--- a/helm/ingress-controller/templates/credentials-secret.yaml
+++ b/helm/ingress-controller/templates/credentials-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "kubernetes-ingress-controller.credentialsSecretName" .}}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
   API_KEY: {{ required "An ngrok API key is required" .Values.credentials.apiKey | b64enc }}

--- a/helm/ingress-controller/tests/__snapshot__/credentials-secret_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/credentials-secret_test.yaml.snap
@@ -7,4 +7,5 @@ Should match snapshot:
     kind: Secret
     metadata:
       name: RELEASE-NAME-kubernetes-ingress-controller-credentials
+      namespace: NAMESPACE
     type: Opaque

--- a/helm/ingress-controller/tests/credentials-secret_test.yaml
+++ b/helm/ingress-controller/tests/credentials-secret_test.yaml
@@ -22,6 +22,7 @@ tests:
 - it: Should generate a secret with the correct name
   release:
     name: test-release
+    namespace: test-namespace
   set:
     credentials.apiKey: "test-api-key"
     credentials.authtoken: "test-authtoken"
@@ -31,5 +32,6 @@ tests:
     - matchRegex:
         path: metadata.name
         pattern: test-release-*
-
-
+    - matchRegex:
+        path: metadata.namespace
+        pattern: test-namespace


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
When one generates the manifests with `helm template`, you will notice that the resulting manifest to create the secret credentials is missing the `metadata.namespace` key/value.  This is not a problem when one generates the manifests for use in the `default` namespace.  However, the problem shows itself if the goal is to use a namespace other than `default`.

## How
Adds `namespace` to the `credentials-secret.yaml` template.

## Breaking Changes
No.
