### PR TITLE
restrict generate to only our paths (not the whole `.direnv/go`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./api/v1alpha1/"
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ preflight: ## Verifies required things like the go version
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=ngrok-ingress-controller-manager-role crd webhook paths="./..." \
+	$(CONTROLLER_GEN) rbac:roleName=ngrok-ingress-controller-manager-role crd webhook paths="./api/v1alpha1/" \
 		output:crd:artifacts:config=$(HELM_TEMPLATES_DIR)/crds \
 		output:rbac:artifacts:config=$(HELM_TEMPLATES_DIR)/rbac
 


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
Running `make` second time (after cleaning `.direnv/` directory) results in the following error:
Error: err: exit status 1: stderr: go: cannot load module listed in go.work file: open ~/kubernetes-ingress-controller/.direnv/go/pkg/mod/golang.ngrok.com/ngrok@v1.0.1-0.20230502190252-9115810884ac/examples/go.mod: no such file or directory

## How
Since we actually moved `$GOPATH` to `./direnv/go` in the previous PR, now the controller gen sees many more things than we intend it to. Restrict it to only things we care about.

## Breaking Changes
None
