### PR TITLE
feat: Add Support for setting pod/node affinity & anti-affinity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: docker-build manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	helm dep update $(HELM_CHART_DIR) && \
 	helm upgrade ngrok-ingress-controller $(HELM_CHART_DIR) --install \
 		--namespace ngrok-ingress-controller \
 		--create-namespace \

--- a/Makefile
+++ b/Makefile
@@ -168,16 +168,19 @@ $(ENVTEST): $(LOCALBIN)
 
 ##@ Helm
 
+.PHONY: _helm_setup
+_helm_setup:
+	./scripts/helm-setup.sh
+	helm dependency update $(HELM_CHART_DIR)
+
 .PHONY: helm-lint
-helm-lint: ## Lint the helm chart
+helm-lint: _helm_setup ## Lint the helm chart
 	helm lint $(HELM_CHART_DIR)
 
 .PHONY: helm-test
-helm-test: ## Run helm unittest plugin
-	./scripts/helm-setup.sh
+helm-test: _helm_setup ## Run helm unittest plugin
 	helm unittest --helm3 $(HELM_CHART_DIR)
 
 .PHONY: helm-update-snapshots
-helm-update-snapshots: ## Update helm unittest snapshots
-	./scripts/helm-setup.sh
+helm-update-snapshots: _helm_setup ## Update helm unittest snapshots
 	helm unittest --helm3 -u $(HELM_CHART_DIR)

--- a/helm/ingress-controller/.gitignore
+++ b/helm/ingress-controller/.gitignore
@@ -1,0 +1,2 @@
+# Charts are downloaded at install time with `helm dep build`
+charts

--- a/helm/ingress-controller/Chart.lock
+++ b/helm/ingress-controller/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 2.4.0
+digest: sha256:577dacb7d21d680beb0614f6f25a1acf66ca9debbd5697a89e6f2786e178f426
+generated: "2023-06-24T18:33:23.812243364-05:00"

--- a/helm/ingress-controller/Chart.yaml
+++ b/helm/ingress-controller/Chart.yaml
@@ -13,3 +13,9 @@ home: https://ngrok.com
 sources:
   - https://github.com/ngrok/kubernetes-ingress-controller
 icon: https://ngrok.com/static/img/brand/ngrok-favicon.svg
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 2.x.x

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -66,6 +66,12 @@ To uninstall the chart:
 | `region`                     | ngrok region to create tunnels in. Defaults to connect to the closest geographical region.                            | `""`                                  |
 | `serverAddr`                 | This is the URL of the ngrok server to connect to. You should set this if you are using a custom ingress URL.         | `""`                                  |
 | `metaData`                   | This is a map of key/value pairs that will be added as meta data to all ngrok api resources created                   | `{}`                                  |
+| `affinity`                   | Affinity for the controller pod assignment                                                                            | `{}`                                  |
+| `podAffinityPreset`          | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                   | `""`                                  |
+| `podAntiAffinityPreset`      | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `soft`                                |
+| `nodeAffinityPreset.type`    | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                                  |
+| `nodeAffinityPreset.key`     | Node label key to match. Ignored if `affinity` is set.                                                                | `""`                                  |
+| `nodeAffinityPreset.values`  | Node label values to match. Ignored if `affinity` is set.                                                             | `[]`                                  |
 | `resources.limits`           | The resources limits for the container                                                                                | `{}`                                  |
 | `resources.requests`         | The requested resources for the container                                                                             | `{}`                                  |
 | `extraVolumes`               | An array of extra volumes to add to the controller.                                                                   | `[]`                                  |

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -1,9 +1,10 @@
+{{- $component := "controller" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     {{- include "kubernetes-ingress-controller.labels" . | nindent 4 }}
-    app.kubernetes.io/component: controller
+    app.kubernetes.io/component: {{ $component }}
   name: {{ include "kubernetes-ingress-controller.fullname" . }}-manager
   namespace: {{ .Release.Namespace }}
   annotations:
@@ -17,7 +18,7 @@ spec:
       {{- if .Values.podLabels }}
         {{- toYaml .Values.podLabels | nindent 6 }}
       {{- end }}
-      app.kubernetes.io/component: controller
+      app.kubernetes.io/component: {{ $component }}
   template:
     metadata:
       annotations:
@@ -32,8 +33,16 @@ spec:
         {{- if .Values.podLabels }}
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
-        app.kubernetes.io/component: controller
+        app.kubernetes.io/component: {{ $component }}
     spec:
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "component" $component "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "component" $component "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
       serviceAccountName: {{ template "kubernetes-ingress-controller.serviceAccountName" . }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -34,6 +34,19 @@ Should match all-options snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubernetes-ingress-controller
         spec:
+          affinity:
+            nodeAffinity: null
+            podAffinity: null
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/component: controller
+                      app.kubernetes.io/instance: RELEASE-NAME
+                      app.kubernetes.io/name: kubernetes-ingress-controller
+                  topologyKey: kubernetes.io/hostname
+                weight: 1
           containers:
           - args:
             - --controller-name=k8s.ngrok.com/ingress-controller
@@ -431,6 +444,19 @@ Should match default snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: kubernetes-ingress-controller
         spec:
+          affinity:
+            nodeAffinity: null
+            podAffinity: null
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/component: controller
+                      app.kubernetes.io/instance: RELEASE-NAME
+                      app.kubernetes.io/name: kubernetes-ingress-controller
+                  topologyKey: kubernetes.io/hostname
+                weight: 1
           containers:
           - args:
             - --controller-name=k8s.ngrok.com/ingress-controller

--- a/helm/ingress-controller/tests/controller-deployment_test.yaml
+++ b/helm/ingress-controller/tests/controller-deployment_test.yaml
@@ -115,3 +115,78 @@ tests:
   - contains:
       path: spec.template.spec.containers[0].args
       content: --zap-stacktrace-level=error
+- it: Defaults to having "soft" pod anti-affinity
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity.podAntiAffinity
+      value:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: controller
+                app.kubernetes.io/instance: RELEASE-NAME
+                app.kubernetes.io/name: kubernetes-ingress-controller
+            topologyKey: kubernetes.io/hostname
+          weight: 1
+- it: Easily allows for setting a "hard" pod anti-affinity
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  set:
+    podAntiAffinityPreset: "hard"
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity.podAntiAffinity
+      value:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+              app.kubernetes.io/instance: RELEASE-NAME
+              app.kubernetes.io/name: kubernetes-ingress-controller
+          topologyKey: kubernetes.io/hostname
+- it: Allows overriding the full affinity
+  template: controller-deployment.yaml
+  documentIndex: 0 # Document 0 is the deployment since its the first template
+  set:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+              - antarctica-east1
+              - antarctica-west1
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+            - key: another-node-label-key
+              operator: In
+              values:
+              - another-node-label-value
+  asserts:
+  - equal:
+      path: spec.template.spec.affinity
+      value:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - antarctica-east1
+                - antarctica-west1
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: another-node-label-key
+                operator: In
+                values:
+                - another-node-label-value

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -73,6 +73,39 @@ serverAddr: ""
 ## @param metaData This is a map of key/value pairs that will be added as meta data to all ngrok api resources created
 metaData: {}
 
+## @param affinity Affinity for the controller pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
+##
+affinity: {}
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAffinityPreset: ""
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAntiAffinityPreset: soft
+## Node affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+##
+nodeAffinityPreset:
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ##
+  type: ""
+  ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set.
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+
 ## Controller container resource requests and limits
 ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ## We usually recommend not to specify default resources and to leave this as a conscious

--- a/scripts/helm-setup.sh
+++ b/scripts/helm-setup.sh
@@ -11,6 +11,11 @@ function cleanup() {
 trap cleanup EXIT
 
 
+function uninstall_helm_plugin() {
+    local plugin_name=$1
+    helm plugin uninstall $plugin_name
+}
+
 # Installs a plugin for helm if it is not already installed.
 function helm_install_plugin() {
     local plugin_name=$1
@@ -26,8 +31,21 @@ function helm_install_plugin() {
             exit 1
         fi
     else
-        echo "Helm plugin $plugin_name already installed"
+        ## Check if version is correct
+        if ! helm plugin list | grep -q $plugin_version; then
+            echo "Helm plugin $plugin_name installed but wrong version. Uninstalling and installing desired version..."
+            uninstall_helm_plugin $plugin_name
+
+            helm plugin install $plugin_source --version $plugin_version >> HELM_PLUGIN_INSTALL.log 2>&1
+            if [ $? -ne 0 ]; then
+                echo "Failed to install helm plugin $plugin_name"
+                cat HELM_PLUGIN_INSTALL.log
+                exit 1
+            fi
+        else
+            echo "Helm plugin $plugin_name already installed and up to date"
+        fi
     fi
 }
 
-helm_install_plugin "unittest" "https://github.com/quintush/helm-unittest" "0.2.10"
+helm_install_plugin "unittest" "https://github.com/quintush/helm-unittest" "0.2.11"


### PR DESCRIPTION
Fixes #254 

## What
Adds support for setting pod & node affinity/anti-affinity via helm chart values.

## How
* Adds `bitnami` common as a dependency for its library of helpers.
* If no `affinity` is set, it adds a default "soft" pod anti-affinity.

## Breaking Changes
No.
