### PR TITLE
Skip releasing chart if the release already exists

### DIFF
--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -57,9 +57,10 @@ jobs:
           version: v3.10.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Version }}" # Publishes a new release. Ex: helm-chart-0.1.0
+          CR_SKIP_EXISTING: "true"
         with:
           charts_dir: helm


### PR DESCRIPTION
## What
* Updates the chart-release-action version
* Skips creating a release if it already exists

## How
* Bump the GH Action version
* set `CR_SKIP_EXISTING: "true"`

## Breaking Changes
No
