### PR TITLE
Handle special case for changing auth types that causes an error duri…

### DIFF
--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -271,7 +271,7 @@ func (r *HTTPSEdgeReconciler) reconcileRoutes(ctx context.Context, edge *ingress
 			EdgeID:    edge.Status.ID,
 			ID:        route.ID,
 			Match:     routeSpec.Match,
-			MatchType: routeSpec.MatchType, // TODO: Check the Match Type here. Otherwise Updates can fail with this error: "HTTP 400: Route match expression '/' must be unique across all routes for HTTPS edge
+			MatchType: routeSpec.MatchType,
 			Backend: &ngrok.EndpointBackendMutate{
 				BackendID: backend.ID,
 			},

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -938,24 +938,21 @@ func (r *HTTPSEdgeReconciler) takeOfflineWithoutAuth(ctx context.Context, route 
 	}
 
 	if route.OAuth != nil {
-		err = routeClientSet.OAuth().Delete(ctx, edgeRouteItem(route))
-		if err != nil {
+		if err := routeClientSet.OAuth().Delete(ctx, edgeRouteItem(route)); err != nil {
 			return err
 		}
 		route.OAuth = nil
 	}
 
 	if route.OIDC != nil {
-		err = routeClientSet.OIDC().Delete(ctx, edgeRouteItem(route))
-		if err != nil {
+		if err := routeClientSet.OIDC().Delete(ctx, edgeRouteItem(route)); err != nil {
 			return err
 		}
 		route.OIDC = nil
 	}
 
 	if route.SAML != nil {
-		err = routeClientSet.SAML().Delete(ctx, edgeRouteItem(route))
-		if err != nil {
+		if err := routeClientSet.SAML().Delete(ctx, edgeRouteItem(route)); err != nil {
 			return err
 		}
 		route.SAML = nil

--- a/internal/controllers/httpsedge_controller_test.go
+++ b/internal/controllers/httpsedge_controller_test.go
@@ -1,0 +1,38 @@
+package controllers
+
+import (
+	"testing"
+
+	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/v1alpha1"
+	"github.com/ngrok/ngrok-api-go/v5"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controllers package Test Suite")
+}
+
+var _ = Describe("HTTPSEdgeController", func() {
+	DescribeTable("isMigratingAuthProviders", func(current *ngrok.HTTPSEdgeRoute, desired *ingressv1alpha1.HTTPSEdgeRouteSpec, expected bool) {
+		Expect(isMigratingAuthProviders(current, desired)).To(Equal(expected))
+	},
+		Entry("no auth", &ngrok.HTTPSEdgeRoute{}, &ingressv1alpha1.HTTPSEdgeRouteSpec{}, false),
+		Entry("Same Auth: Oauth", &ngrok.HTTPSEdgeRoute{OAuth: &ngrok.EndpointOAuth{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{OAuth: &ingressv1alpha1.EndpointOAuth{}}, false),
+		Entry("Same Auth: SAML", &ngrok.HTTPSEdgeRoute{SAML: &ngrok.EndpointSAML{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{SAML: &ingressv1alpha1.EndpointSAML{}}, false),
+		Entry("Same Auth: OIDC", &ngrok.HTTPSEdgeRoute{OIDC: &ngrok.EndpointOIDC{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{OIDC: &ingressv1alpha1.EndpointOIDC{}}, false),
+		Entry("Added Oauth", &ngrok.HTTPSEdgeRoute{}, &ingressv1alpha1.HTTPSEdgeRouteSpec{OAuth: &ingressv1alpha1.EndpointOAuth{}}, false),
+		Entry("Added SAML", &ngrok.HTTPSEdgeRoute{}, &ingressv1alpha1.HTTPSEdgeRouteSpec{SAML: &ingressv1alpha1.EndpointSAML{}}, false),
+		Entry("Added OIDC", &ngrok.HTTPSEdgeRoute{}, &ingressv1alpha1.HTTPSEdgeRouteSpec{OIDC: &ingressv1alpha1.EndpointOIDC{}}, false),
+		Entry("Removed Oauth", &ngrok.HTTPSEdgeRoute{OAuth: &ngrok.EndpointOAuth{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{}, false),
+		Entry("Removed SAML", &ngrok.HTTPSEdgeRoute{SAML: &ngrok.EndpointSAML{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{}, false),
+		Entry("Removed OIDC", &ngrok.HTTPSEdgeRoute{OIDC: &ngrok.EndpointOIDC{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{}, false),
+		Entry("Removed Oauth and Added Saml", &ngrok.HTTPSEdgeRoute{OAuth: &ngrok.EndpointOAuth{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{SAML: &ingressv1alpha1.EndpointSAML{}}, true),
+		Entry("Removed Oauth and Added OIDC", &ngrok.HTTPSEdgeRoute{OAuth: &ngrok.EndpointOAuth{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{OIDC: &ingressv1alpha1.EndpointOIDC{}}, true),
+		Entry("Removed SAML and Added Oauth", &ngrok.HTTPSEdgeRoute{SAML: &ngrok.EndpointSAML{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{OAuth: &ingressv1alpha1.EndpointOAuth{}}, true),
+		Entry("Removed SAML and Added OIDC", &ngrok.HTTPSEdgeRoute{SAML: &ngrok.EndpointSAML{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{OIDC: &ingressv1alpha1.EndpointOIDC{}}, true),
+		Entry("Removed OIDC and Added Oauth", &ngrok.HTTPSEdgeRoute{OIDC: &ngrok.EndpointOIDC{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{OAuth: &ingressv1alpha1.EndpointOAuth{}}, true),
+		Entry("Removed OIDC and Added SAML", &ngrok.HTTPSEdgeRoute{OIDC: &ngrok.EndpointOIDC{}}, &ingressv1alpha1.HTTPSEdgeRouteSpec{SAML: &ingressv1alpha1.EndpointSAML{}}, true),
+	)
+})


### PR DESCRIPTION
…ng state transition

<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What

If you have auth (Oauth, Saml, OIDC) setup on a route and try to change to a different one in 1 apply, you get stuck in an error case. The ngrok api won't let you have more than 1 auth type on a route. You can transition from Oauth to OIDC because of the order the controller code handles the modules, but you can't go the other way. 

This change allows you to make a manifest change to move from 1 auth type to another without the risk of leaving it open in a failed state. 

## How

Before working on a single route, we first check if we are in a state where we are moving between 2 auth types. If so, we disable the routes backend, remove the existing configs, and then add the other configs as normal after. 

Before this change, moving from a OIDC module to an OAuth one gave this error

```
2023-06-27T05:09:08Z	DEBUG	events	HTTP 400: The edge specifies conflicting authentication modules. Only one of SAML, OIDC, or OAuth may be enabled. [ERR_NGROK_7079]

Operation ID: op_2Rm5jDE7DflBSviAhTxtJP1ZA0T	{"type": "Warning", "object": {"kind":"HTTPSEdge","namespace":"ngrok-ingress-controller","name":"bezek-local-oauth-fix-ngrok-app","uid":"d5501be3-34c7-4ede-937f-c3dbc2752143","apiVersion":"ingress.k8s.ngrok.com/v1alpha1","resourceVersion":"22689"}, "reason": "RouteModuleUpdateFailed"}
```

After this update, you can migrate freely between the two types of Auth configs. 

## Breaking Changes
This does create downtime during the update as it removes the backend during the process. 
