### PR TITLE
Helm chart Release candidate 0.11.0-rc.1

### DIFF
--- a/helm/ingress-controller/CHANGELOG.md
+++ b/helm/ingress-controller/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Specify IPPolicyRule action as an enum of (allow,deny) as part of [#260](https://github.com/ngrok/kubernetes-ingress-controller/pull/260)
+
+### Added
+- Add support for configuring pod affinities, pod disruption budget, and priorityClassName [#258](https://github.com/ngrok/kubernetes-ingress-controller/pull/258)
+
 ## 0.10.0
 
 ### Added

--- a/helm/ingress-controller/Chart.yaml
+++ b/helm/ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubernetes-ingress-controller
 description: A Kubernetes ingress controller built using ngrok.
-version: 0.10.0
+version: 0.11.0-rc.1
 appVersion: 0.8.0
 keywords:
   - ngrok

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -13,7 +13,7 @@ Should match all-options snapshot:
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
         app.kubernetes.io/version: 0.8.0
-        helm.sh/chart: kubernetes-ingress-controller-0.10.0
+        helm.sh/chart: kubernetes-ingress-controller-0.11.0-rc.1
       name: RELEASE-NAME-kubernetes-ingress-controller-manager
       namespace: NAMESPACE
     spec:
@@ -423,7 +423,7 @@ Should match default snapshot:
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
         app.kubernetes.io/version: 0.8.0
-        helm.sh/chart: kubernetes-ingress-controller-0.10.0
+        helm.sh/chart: kubernetes-ingress-controller-0.11.0-rc.1
       name: RELEASE-NAME-kubernetes-ingress-controller-manager
       namespace: NAMESPACE
     spec:

--- a/helm/ingress-controller/tests/__snapshot__/controller-pdb_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-pdb_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot:
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
         app.kubernetes.io/version: 0.8.0
-        helm.sh/chart: kubernetes-ingress-controller-0.10.0
+        helm.sh/chart: kubernetes-ingress-controller-0.11.0-rc.1
       name: test-release-kubernetes-ingress-controller-controller-pdb
       namespace: test-namespace
     spec:

--- a/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
@@ -10,6 +10,6 @@ Should match the snapshot:
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
         app.kubernetes.io/version: 0.8.0
-        helm.sh/chart: kubernetes-ingress-controller-0.10.0
+        helm.sh/chart: kubernetes-ingress-controller-0.11.0-rc.1
       name: test-release-kubernetes-ingress-controller
       namespace: test-namespace

--- a/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -10,7 +10,7 @@ Should match snapshot:
         app.kubernetes.io/name: kubernetes-ingress-controller
         app.kubernetes.io/part-of: kubernetes-ingress-controller
         app.kubernetes.io/version: 0.8.0
-        helm.sh/chart: kubernetes-ingress-controller-0.10.0
+        helm.sh/chart: kubernetes-ingress-controller-0.11.0-rc.1
       name: ngrok
     spec:
       controller: k8s.ngrok.com/ingress-controller


### PR DESCRIPTION
## What

Creates a release candidate of the helm chart for testing purposes

## How
* Updating the `CHANGELOG` with the changes that will be in the RC but are unreleased.
* Change the version of the helm chart to specify a RC. Since it doesn't follow semver, it won't appear in `helm search repo ngrok` unless we add the `--devel` flag

## Breaking Changes

No