### PR TITLE
fix: Remove unnecessary break in sync create/update loops

### DIFF
--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -203,7 +203,6 @@ func (d *Driver) Sync(ctx context.Context, c client.Client) error {
 				d.log.Error(err, "error creating domain", "domain", desiredDomain)
 				return err
 			}
-			break
 		}
 	}
 	// Don't delete domains to prevent accidentally de-registering them and making people re-do DNS
@@ -228,7 +227,6 @@ func (d *Driver) Sync(ctx context.Context, c client.Client) error {
 			if err := c.Create(ctx, &desiredEdge); err != nil {
 				return err
 			}
-			break
 		}
 	}
 
@@ -269,7 +267,6 @@ func (d *Driver) Sync(ctx context.Context, c client.Client) error {
 				d.log.Error(err, "error creating tunnel", "tunnel", desiredTunnel)
 				return err
 			}
-			break
 		}
 	}
 


### PR DESCRIPTION
## What

These break statements shouldn't be here. They are breaking the out of the outer loop and are likely causing some of the desired domains, tunnels, edges not being created as fast as they could be. Luckily, they'll be caught in the next sync loop since they will exist and follow the update flow and the inner for loop will be broken, moving onto the next one

## How

Remove the unnecessary break statements which cause reconciliation to take longer

## Breaking Changes

No
