### PR TITLE
add caching to docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN --mount=type=cache,target=/go \
+	go mod download
 
 # Copy the go source
 COPY . .
@@ -15,7 +16,8 @@ COPY . .
 ARG TARGETOS TARGETARCH
 
 # Build
-RUN CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" make _build
+RUN --mount=type=cache,target=/go \
+	CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" make _build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
## What

Use the fancy buildkit --mount option to cache the /go directory between
builds.
