### PR TITLE
fix: Don't remove httpsedges/tunnels that weren't created by the ingr…

### DIFF
--- a/internal/store/annotations.go
+++ b/internal/store/annotations.go
@@ -1,0 +1,16 @@
+package store
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+const (
+	annotationIngressControllerManaged = "ingress.k8s.ngrok.com/ingress-controller-managed"
+)
+
+func hasControllerManagedAnnotation(obj client.Object) bool {
+	annotations := obj.GetAnnotations()
+	v, ok := annotations[annotationIngressControllerManaged]
+	if !ok {
+		return false
+	}
+	return v == "true"
+}

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -188,7 +188,7 @@ func (d *Driver) Sync(ctx context.Context, c client.Client) error {
 		for _, currDomain := range currDomains.Items {
 			if desiredDomain.Name == currDomain.Name && desiredDomain.Namespace == currDomain.Namespace {
 				// It matches so lets update it if anything is different
-				// or if it doesn't have a an annotation that its managed by
+				// or if it doesn't have an annotation that it is managed by
 				// the ingress controller.
 				if !reflect.DeepEqual(desiredDomain.Spec, currDomain.Spec) || !hasControllerManagedAnnotation(&currDomain) {
 					currDomain.Spec = desiredDomain.Spec


### PR DESCRIPTION
Fixes #267 

## What

Fixes Tunnels and HTTPSEdges that weren't created by the ingress controller getting deleted. 

## How

If an Edge or Tunnel are created by the ingress controller to fulfill an Ingress, add an annotation that they are managed by the 
Ingress Controller. When we look to delete dangling tunnels and edges, only do so if they were managed by the controller.

## Testing

Logs:

```
2023-07-03T21:21:10Z	LEVEL(-3)	cache-store-driver	Not deleting tunnel because it is not managed by ingress controller	{"V1Alpha1Tunnel": "default/test-app-3-80"}
2023-07-03T21:21:10Z	LEVEL(-3)	cache-store-driver	Not deleting tunnel because it is not managed by ingress controller	{"V1Alpha1Tunnel": "default/starwars-tunnel"}
```

## Breaking Changes
No.
