### PR TITLE
hack around the lack of static domain support in the API

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,13 +180,15 @@ func runController(ctx context.Context, opts managerOpts) error {
 		return fmt.Errorf("unable to create ingress controller: %w", err)
 	}
 
-	if err = (&controllers.DomainReconciler{
+	domainReconciler := &controllers.DomainReconciler{
 		Client:        mgr.GetClient(),
 		Log:           ctrl.Log.WithName("controllers").WithName("domain"),
 		Scheme:        mgr.GetScheme(),
 		Recorder:      mgr.GetEventRecorderFor("domain-controller"),
 		DomainsClient: ngrokClientset.Domains(),
-	}).SetupWithManager(mgr); err != nil {
+	}
+
+	if err = domainReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Domain")
 		os.Exit(1)
 	}
@@ -220,11 +222,12 @@ func runController(ctx context.Context, opts managerOpts) error {
 		os.Exit(1)
 	}
 	if err = (&controllers.HTTPSEdgeReconciler{
-		Client:         mgr.GetClient(),
-		Log:            ctrl.Log.WithName("controllers").WithName("https-edge"),
-		Scheme:         mgr.GetScheme(),
-		Recorder:       mgr.GetEventRecorderFor("https-edge-controller"),
-		NgrokClientset: ngrokClientset,
+		Client:           mgr.GetClient(),
+		Log:              ctrl.Log.WithName("controllers").WithName("https-edge"),
+		Scheme:           mgr.GetScheme(),
+		Recorder:         mgr.GetEventRecorderFor("https-edge-controller"),
+		NgrokClientset:   ngrokClientset,
+		DomainReconciler: domainReconciler,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HTTPSEdge")
 		os.Exit(1)


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What

Free-tier static domains don't exist in the API currently, so the domain
CRD will never get reconciled. Work around this by marking un-reconciled
domains as "maybe-static" in the httpsedges controller, and then as
"probably definitely static" in the domains controller if it was a
maybe-static that got a license error when trying to create it for
realz.

