### PR TITLE
Do not delete CRs that the controller didn't create

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,3 @@
 layout go
+dotenv_if_exists
 use flake

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ testbin/*
 e2e-fixtures/*/config*.yaml
 
 /.direnv
+.env

--- a/helm/ingress-controller/Chart.lock
+++ b/helm/ingress-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.5.0
-digest: sha256:3729f38a9dcdc1cd698b0902954a77656c1f40940a76beed0f2aeb917bb133e5
-generated: "2023-07-03T14:56:23.248937724-05:00"
+  version: 2.6.0
+digest: sha256:6657a16696e9c132a98eb257951876f491f213b55aac7b4894993d260b2bae09
+generated: "2023-07-11T17:18:54.282801-04:00"

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -81,6 +81,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --election-id={{ include "kubernetes-ingress-controller.fullname" . }}-leader
+        - --runtime-config-name={{ include "kubernetes-ingress-controller.fullname" . }}-runtime-config
         securityContext:
           allowPrivilegeEscalation: false
         env:

--- a/internal/store/annotations.go
+++ b/internal/store/annotations.go
@@ -1,0 +1,23 @@
+package store
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+const (
+	annotationIngressControllerManaged = "ingress.k8s.ngrok.com/ingress-controller-managed"
+)
+
+func isControllerManaged(obj client.Object) bool {
+	if v, ok := obj.GetAnnotations()[annotationIngressControllerManaged]; ok {
+		return v == "true"
+	}
+	return false
+}
+
+func setControllerManaged(obj client.Object) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[annotationIngressControllerManaged] = "true"
+	obj.SetAnnotations(annotations)
+}

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -194,6 +194,27 @@ func (d *Driver) Migrate(ctx context.Context, c client.Client) error {
 	return nil
 }
 
+func (d *Driver) PrintDebug(log logr.Logger) {
+	ings := d.store.ListNgrokIngressesV1()
+	for _, ing := range ings {
+		log.Info("found matching ingress", "ingress-name", ing.Name, "ingress-namespace", ing.Namespace)
+	}
+
+	// Helpful debug information if someone doesn't have their ingress class set up correctly.
+	if len(ings) == 0 {
+		ingresses := d.store.ListIngressesV1()
+		ngrokIngresses := d.store.ListNgrokIngressesV1()
+		ingressClasses := d.store.ListIngressClassesV1()
+		ngrokIngressClasses := d.store.ListNgrokIngressClassesV1()
+		log.Info("no matching ingresses found",
+			"all ingresses", ingresses,
+			"all ngrok ingresses", ngrokIngresses,
+			"all ingress classes", ingressClasses,
+			"all ngrok ingress classes", ngrokIngressClasses,
+		)
+	}
+}
+
 func (d *Driver) UpdateIngress(ingress *netv1.Ingress) (bool, error) {
 	// Ensure the ingress object is up to date in the store
 	if err := d.store.Update(ingress); err != nil {

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -414,6 +414,7 @@ func (d *Driver) calculateDomains() []ingressv1alpha1.Domain {
 					Domain: rule.Host,
 				},
 			}
+			setControllerManaged(&domain)
 			domain.Spec.Metadata = d.customMetadata
 			domainMap[rule.Host] = domain
 		}
@@ -463,6 +464,7 @@ func (d *Driver) calculateHTTPSEdges() []ingressv1alpha1.HTTPSEdge {
 				Hostports: []string{domain.Spec.Domain + ":443"},
 			},
 		}
+		setControllerManaged(&edge)
 		edge.Spec.Metadata = d.customMetadata
 		var ngrokRoutes []ingressv1alpha1.HTTPSEdgeRouteSpec
 		for _, ingress := range ingresses {
@@ -573,7 +575,7 @@ func (d *Driver) calculateTunnels() []ingressv1alpha1.Tunnel {
 				tunnelAddr := fmt.Sprintf("%s.%s.%s:%d", serviceName, namespace, clusterDomain, servicePort)
 				tunnelName := fmt.Sprintf("%s-%d", serviceName, servicePort)
 
-				namespaceTunnels[tunnelName] = ingressv1alpha1.Tunnel{
+				tunnel := ingressv1alpha1.Tunnel{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      tunnelName,
 						Namespace: ingress.Namespace,
@@ -586,6 +588,8 @@ func (d *Driver) calculateTunnels() []ingressv1alpha1.Tunnel {
 						},
 					},
 				}
+				setControllerManaged(&tunnel)
+				namespaceTunnels[tunnelName] = tunnel
 			}
 		}
 	}

--- a/internal/store/driver_test.go
+++ b/internal/store/driver_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Driver", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, obj := range obs {
-				foundObj, found, err := driver.Get(obj)
+				foundObj, found, err := driver.store.Get(obj)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(foundObj).ToNot(BeNil())
@@ -69,13 +69,13 @@ var _ = Describe("Driver", func() {
 			err := driver.Seed(context.Background(), c)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = driver.DeleteIngress(types.NamespacedName{
+			err = driver.DeleteNamedIngress(types.NamespacedName{
 				Namespace: "test-namespace",
 				Name:      "test-ingress",
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			foundObj, found, err := driver.Get(&i1)
+			foundObj, found, err := driver.store.Get(&i1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeFalse())
 			Expect(foundObj).To(BeNil())
@@ -116,7 +116,7 @@ var _ = Describe("Driver", func() {
 				c := fake.NewFakeClientWithScheme(scheme, obs...)
 
 				for _, obj := range obs {
-					err := driver.Update(obj)
+					err := driver.store.Update(obj)
 					Expect(err).ToNot(HaveOccurred())
 				}
 				err := driver.Seed(context.Background(), c)
@@ -364,14 +364,14 @@ var _ = Describe("Driver", func() {
 					},
 				},
 			}
-			driver.Add(ms1)
-			driver.Add(ms2)
-			driver.Add(ms3)
+			driver.store.Add(ms1)
+			driver.store.Add(ms2)
+			driver.store.Add(ms3)
 		})
 
 		It("Should return an empty module set if the ingress has no modules annotaion", func() {
 			ing := NewTestIngressV1("test-ingress", "test")
-			Expect(driver.Add(&ing)).To(BeNil())
+			Expect(driver.store.Add(&ing)).To(BeNil())
 
 			ms, err := driver.getNgrokModuleSetForIngress(&ing)
 			Expect(err).To(BeNil())
@@ -385,7 +385,7 @@ var _ = Describe("Driver", func() {
 		It("Should return the matching module set if the ingress has a modules annotaion", func() {
 			ing := NewTestIngressV1("test-ingress", "test")
 			ing.SetAnnotations(map[string]string{"k8s.ngrok.com/modules": "ms1"})
-			Expect(driver.Add(&ing)).To(BeNil())
+			Expect(driver.store.Add(&ing)).To(BeNil())
 
 			ms, err := driver.getNgrokModuleSetForIngress(&ing)
 			Expect(err).To(BeNil())
@@ -395,7 +395,7 @@ var _ = Describe("Driver", func() {
 		It("merges modules with the last one winning if multiple module sets are specified", func() {
 			ing := NewTestIngressV1("test-ingress", "test")
 			ing.SetAnnotations(map[string]string{"k8s.ngrok.com/modules": "ms1,ms2,ms3"})
-			Expect(driver.Add(&ing)).To(BeNil())
+			Expect(driver.store.Add(&ing)).To(BeNil())
 
 			ms, err := driver.getNgrokModuleSetForIngress(&ing)
 			Expect(err).To(BeNil())

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -338,12 +338,8 @@ func (s Store) shouldHandleIngressCheckClass(ing *netv1.Ingress) (bool, error) {
 // shouldHandleIngressIsValid checks if the ingress should be handled by the controller based on the ingress spec
 func (s Store) shouldHandleIngressIsValid(ing *netv1.Ingress) (bool, error) {
 	errs := errors.NewErrInvalidIngressSpec()
-	if len(ing.Spec.Rules) > 1 {
-		errs.AddError(fmt.Sprintf("A maximum of one rule is required to be set"))
-	}
-	if len(ing.Spec.Rules) == 0 {
-		errs.AddError(fmt.Sprintf("At least one rule is required to be set"))
-	} else {
+	switch len(ing.Spec.Rules) {
+	case 1:
 		if ing.Spec.Rules[0].Host == "" {
 			errs.AddError(fmt.Sprintf("A host is required to be set"))
 		}
@@ -353,6 +349,10 @@ func (s Store) shouldHandleIngressIsValid(ing *netv1.Ingress) (bool, error) {
 				errs.AddError(fmt.Sprintf("Resource backends are not supported"))
 			}
 		}
+	case 0:
+		errs.AddError(fmt.Sprintf("At least one rule is required to be set"))
+	default:
+		errs.AddError(fmt.Sprintf("A maximum of one rule is required to be set"))
 	}
 
 	if errs.HasErrors() {

--- a/internal/store/updatestorehandler.go
+++ b/internal/store/updatestorehandler.go
@@ -30,7 +30,7 @@ func NewUpdateStoreHandler(resourceName string, d *Driver) *UpdateStoreHandler {
 
 // Create is called in response to an create event - e.g. Edge Creation.
 func (e *UpdateStoreHandler) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
-	if err := e.driver.Update(evt.Object); err != nil {
+	if err := e.driver.store.Update(evt.Object); err != nil {
 		e.log.Error(err, "error updating object in create", "object", evt.Object)
 		return
 	}
@@ -38,7 +38,7 @@ func (e *UpdateStoreHandler) Create(evt event.CreateEvent, q workqueue.RateLimit
 
 // Update is called in response to an update event -  e.g. Edge Updated.
 func (e *UpdateStoreHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	if err := e.driver.Update(evt.ObjectNew); err != nil {
+	if err := e.driver.store.Update(evt.ObjectNew); err != nil {
 		e.log.Error(err, "error updating object in update", "object", evt.ObjectNew)
 		return
 	}
@@ -46,7 +46,7 @@ func (e *UpdateStoreHandler) Update(evt event.UpdateEvent, q workqueue.RateLimit
 
 // Delete is called in response to a delete event - e.g. Edge Deleted.
 func (e *UpdateStoreHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
-	if err := e.driver.Delete(evt.Object); err != nil {
+	if err := e.driver.store.Delete(evt.Object); err != nil {
 		e.log.Error(err, "error deleting object", "object", evt.Object)
 		return
 	}
@@ -55,7 +55,7 @@ func (e *UpdateStoreHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimit
 // Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
 // external trigger request
 func (e *UpdateStoreHandler) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
-	if err := e.driver.Update(evt.Object); err != nil {
+	if err := e.driver.store.Update(evt.Object); err != nil {
 		e.log.Error(err, "error updating object in generic", "object", evt.Object)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -285,24 +285,7 @@ func getDriver(ctx context.Context, mgr manager.Manager, options managerOpts) (*
 		return nil, fmt.Errorf("unable to migrate store: %w", err)
 	}
 
-	// ings := d.ListNgrokIngressesV1()
-	// for _, ing := range ings {
-	// 	setupLog.Info("found matching ingress", "ingress-name", ing.Name, "ingress-namespace", ing.Namespace)
-	// }
-
-	// // Helpful debug information if someone doesn't have their ingress class set up correctly.
-	// if len(ings) == 0 {
-	// 	ingresses := d.ListIngressesV1()
-	// 	ngrokIngresses := d.ListNgrokIngressesV1()
-	// 	ingressClasses := d.ListIngressClassesV1()
-	// 	ngrokIngressClasses := d.ListNgrokIngressClassesV1()
-	// 	setupLog.Info("no matching ingresses found",
-	// 		"all ingresses", ingresses,
-	// 		"all ngrok ingresses", ngrokIngresses,
-	// 		"all ingress classes", ingressClasses,
-	// 		"all ngrok ingress classes", ngrokIngressClasses,
-	// 	)
-	// }
+	d.PrintDebug(setupLog)
 
 	return d, nil
 }

--- a/main.go
+++ b/main.go
@@ -281,24 +281,28 @@ func getDriver(ctx context.Context, mgr manager.Manager, options managerOpts) (*
 		return nil, fmt.Errorf("unable to seed cache store: %w", err)
 	}
 
-	ings := d.ListNgrokIngressesV1()
-	for _, ing := range ings {
-		setupLog.Info("found matching ingress", "ingress-name", ing.Name, "ingress-namespace", ing.Namespace)
+	if err := d.Migrate(ctx, mgr.GetClient()); err != nil {
+		return nil, fmt.Errorf("unable to migrate store: %w", err)
 	}
 
-	// Helpful debug information if someone doesn't have their ingress class set up correctly.
-	if len(ings) == 0 {
-		ingresses := d.ListIngressesV1()
-		ngrokIngresses := d.ListNgrokIngressesV1()
-		ingressClasses := d.ListIngressClassesV1()
-		ngrokIngressClasses := d.ListNgrokIngressClassesV1()
-		setupLog.Info("no matching ingresses found",
-			"all ingresses", ingresses,
-			"all ngrok ingresses", ngrokIngresses,
-			"all ingress classes", ingressClasses,
-			"all ngrok ingress classes", ngrokIngressClasses,
-		)
-	}
+	// ings := d.ListNgrokIngressesV1()
+	// for _, ing := range ings {
+	// 	setupLog.Info("found matching ingress", "ingress-name", ing.Name, "ingress-namespace", ing.Namespace)
+	// }
+
+	// // Helpful debug information if someone doesn't have their ingress class set up correctly.
+	// if len(ings) == 0 {
+	// 	ingresses := d.ListIngressesV1()
+	// 	ngrokIngresses := d.ListNgrokIngressesV1()
+	// 	ingressClasses := d.ListIngressClassesV1()
+	// 	ngrokIngressClasses := d.ListNgrokIngressClassesV1()
+	// 	setupLog.Info("no matching ingresses found",
+	// 		"all ingresses", ingresses,
+	// 		"all ngrok ingresses", ngrokIngresses,
+	// 		"all ingress classes", ingressClasses,
+	// 		"all ngrok ingress classes", ngrokIngressClasses,
+	// 	)
+	// }
 
 	return d, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #267

## What
Up until now, the ingress controller will delete all CRs (`httpsedge` and `tunnel`) that are not actively used by it. This presents a challenge, since in some cases, the operator wants to be able to create things manually without a matching ingress. With this PR, the controller marks any CRs created by it with an annotation, and only deletes CRs which are marked with this annotation.

## How
When the controller starts, it performs one time migration of all CRs and marks them as owned (e.g. adds the annotation). After that newly created CRs will get this annotation automatically. When deleting CRs, it looks for this annotation and ignores anything that doesn't have it.

## Breaking Changes
Since the controller deletes any CRs that it doesn't need, there shouldn't be any manually created ones. The only scenario where this breaks is when the operator shuts down the controller, creates some things manually, and then installs a new version of it. In this case, the controller will adopt anything manually created and the operator will need to clean these up manually.
