### PR TITLE
unified reconciling and error handling

### DIFF
--- a/api/v1alpha1/ngrok_common.go
+++ b/api/v1alpha1/ngrok_common.go
@@ -412,7 +412,3 @@ func (amazon *EndpointOAuthAmazon) ToNgrok(clientSecret *string) *ngrok.Endpoint
 	}
 	return mod
 }
-
-func (d *Domain) GetStatusID() string {
-	return d.Status.ID
-}

--- a/api/v1alpha1/ngrok_common.go
+++ b/api/v1alpha1/ngrok_common.go
@@ -412,3 +412,7 @@ func (amazon *EndpointOAuthAmazon) ToNgrok(clientSecret *string) *ngrok.Endpoint
 	}
 	return mod
 }
+
+func (d *Domain) GetStatusID() string {
+	return d.Status.ID
+}

--- a/internal/controllers/base_controller.go
+++ b/internal/controllers/base_controller.go
@@ -10,7 +10,7 @@ import (
 type ngrokController[T client.Object] interface {
 	client() client.Client
 
-	getStatusID(ct T) string
+	getStatusID(cr T) string
 	create(ctx context.Context, cr T) error
 	update(ctx context.Context, cr T) error
 	delete(ctx context.Context, cr T) error

--- a/internal/controllers/base_controller.go
+++ b/internal/controllers/base_controller.go
@@ -106,9 +106,8 @@ func reconcileResultFromError(err error) (ctrl.Result, error) {
 			return ctrl.Result{}, err
 		case nerr.StatusCode == http.StatusTooManyRequests:
 			return ctrl.Result{RequeueAfter: time.Minute}, nil
-		// case ngrok.IsErrorCode(err, retryCodes...):
-		// 	return ctrl.Result{Requeue: true}, nil
 		default:
+			// the rest are client errors, we don't retry by default
 			return ctrl.Result{}, nil
 		}
 	}

--- a/internal/controllers/base_controller.go
+++ b/internal/controllers/base_controller.go
@@ -65,7 +65,7 @@ func (r *baseController[T]) reconcile(ctx context.Context, req ctrl.Request, cr 
 			if err := r.update(ctx, cr); err != nil {
 				r.Recorder.Event(cr, v1.EventTypeWarning, "UpdateError", fmt.Sprintf("Failed to update %s %s: %s", r.kubeType, crName, err.Error()))
 				if r.errResult != nil {
-					return r.errResult(createOp, cr, err)
+					return r.errResult(updateOp, cr, err)
 				}
 				return reconcileResultFromError(err)
 			}
@@ -80,7 +80,7 @@ func (r *baseController[T]) reconcile(ctx context.Context, req ctrl.Request, cr 
 					if !ngrok.IsNotFound(err) {
 						r.Recorder.Event(cr, v1.EventTypeWarning, "DeleteError", fmt.Sprintf("Failed to delete %s %s: %s", r.kubeType, crName, err.Error()))
 						if r.errResult != nil {
-							return r.errResult(createOp, cr, err)
+							return r.errResult(deleteOp, cr, err)
 						}
 						return reconcileResultFromError(err)
 					}

--- a/internal/controllers/base_controller.go
+++ b/internal/controllers/base_controller.go
@@ -1,0 +1,62 @@
+package controllers
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ngrokObject interface {
+	client.Object
+	GetStatusID() string
+}
+
+type ngrokController[T ngrokObject] interface {
+	client() client.Client
+
+	create(ctx context.Context, cr T) error
+	update(ctx context.Context, cr T) error
+	delete(ctx context.Context, cr T) error
+}
+
+func doReconcile[T ngrokObject](ctx context.Context, req ctrl.Request, cr T, d ngrokController[T]) (ctrl.Result, error) {
+	if err := d.client().Get(ctx, req.NamespacedName, cr); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if isUpsert(cr) {
+		if err := registerAndSyncFinalizer(ctx, d.client(), cr); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if cr.GetStatusID() == "" {
+			if err := d.create(ctx, cr); err != nil {
+				return reconcileResultFromError(err)
+			}
+		} else {
+			if err := d.update(ctx, cr); err != nil {
+				return reconcileResultFromError(err)
+			}
+		}
+	} else {
+		if hasFinalizer(cr) {
+			if cr.GetStatusID() != "" {
+				if err := d.delete(ctx, cr); err != nil {
+					return reconcileResultFromError(err)
+				}
+			}
+
+			if err := removeAndSyncFinalizer(ctx, d.client(), cr); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func reconcileResultFromError(err error) (ctrl.Result, error) {
+	// TODO implement this
+	return ctrl.Result{}, err
+}

--- a/internal/controllers/base_controller.go
+++ b/internal/controllers/base_controller.go
@@ -3,14 +3,24 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/ngrok/ngrok-api-go/v5"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type baseControllerOp int
+
+const (
+	createOp baseControllerOp = iota
+	updateOp
+	deleteOp
 )
 
 type baseController[T client.Object] struct {
@@ -18,37 +28,65 @@ type baseController[T client.Object] struct {
 	Log      logr.Logger
 	Recorder record.EventRecorder
 
-	statusID func(ct T) string
-	create   func(ctx context.Context, cr T) error
-	update   func(ctx context.Context, cr T) error
-	delete   func(ctx context.Context, cr T) error
+	kubeType  string
+	statusID  func(ct T) string
+	create    func(ctx context.Context, cr T) error
+	update    func(ctx context.Context, cr T) error
+	delete    func(ctx context.Context, cr T) error
+	errResult func(op baseControllerOp, cr T, err error) (ctrl.Result, error)
 }
 
 func (r *baseController[T]) reconcile(ctx context.Context, req ctrl.Request, cr T) (ctrl.Result, error) {
+	log := r.Log.WithValues(r.kubeType, req.NamespacedName)
+	ctx = ctrl.LoggerInto(ctx, log)
+
 	if err := r.Kube.Get(ctx, req.NamespacedName, cr); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	crName := req.NamespacedName.String()
 	if isUpsert(cr) {
 		if err := registerAndSyncFinalizer(ctx, r.Kube, cr); err != nil {
 			return ctrl.Result{}, err
 		}
 
 		if r.statusID != nil && r.statusID(cr) == "" {
+			r.Recorder.Event(cr, v1.EventTypeNormal, "Creating", fmt.Sprintf("Creating %s: %s", r.kubeType, crName))
 			if err := r.create(ctx, cr); err != nil {
+				r.Recorder.Event(cr, v1.EventTypeWarning, "CreateError", fmt.Sprintf("Failed to create %s %s: %s", r.kubeType, crName, err.Error()))
+				if r.errResult != nil {
+					return r.errResult(createOp, cr, err)
+				}
 				return reconcileResultFromError(err)
 			}
+			r.Recorder.Event(cr, v1.EventTypeNormal, "Created", fmt.Sprintf("Created %s: %s", r.kubeType, crName))
 		} else {
+			r.Recorder.Event(cr, v1.EventTypeNormal, "Updating", fmt.Sprintf("Updating %s: %s", r.kubeType, crName))
 			if err := r.update(ctx, cr); err != nil {
+				r.Recorder.Event(cr, v1.EventTypeWarning, "UpdateError", fmt.Sprintf("Failed to update %s %s: %s", r.kubeType, crName, err.Error()))
+				if r.errResult != nil {
+					return r.errResult(createOp, cr, err)
+				}
 				return reconcileResultFromError(err)
 			}
+			r.Recorder.Event(cr, v1.EventTypeNormal, "Updated", fmt.Sprintf("Updated %s: %s", r.kubeType, crName))
 		}
 	} else {
 		if hasFinalizer(cr) {
 			if r.statusID == nil || r.statusID(cr) != "" {
+				sid := r.statusID(cr)
+				r.Recorder.Event(cr, v1.EventTypeNormal, "Deleting", fmt.Sprintf("Deleting %s: %s", r.kubeType, crName))
 				if err := r.delete(ctx, cr); err != nil {
-					return reconcileResultFromError(err)
+					if !ngrok.IsNotFound(err) {
+						r.Recorder.Event(cr, v1.EventTypeWarning, "DeleteError", fmt.Sprintf("Failed to delete %s %s: %s", r.kubeType, crName, err.Error()))
+						if r.errResult != nil {
+							return r.errResult(createOp, cr, err)
+						}
+						return reconcileResultFromError(err)
+					}
+					log.Info(fmt.Sprintf("%s not found, assuming it was already deleted", r.kubeType), "ID", sid)
 				}
+				r.Recorder.Event(cr, v1.EventTypeNormal, "Deleted", fmt.Sprintf("Deleted %s: %s", r.kubeType, crName))
 			}
 
 			if err := removeAndSyncFinalizer(ctx, r.Kube, cr); err != nil {
@@ -75,6 +113,5 @@ func reconcileResultFromError(err error) (ctrl.Result, error) {
 		}
 	}
 
-	// TODO implement this
 	return ctrl.Result{}, err
 }

--- a/internal/controllers/domain_controller.go
+++ b/internal/controllers/domain_controller.go
@@ -72,68 +72,17 @@ func (r *DomainReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.1/pkg/reconcile
 func (r *DomainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// log := r.Log.WithValues("V1Alpha1Domain", req.NamespacedName)
 	var controller ngrokController[*ingressv1alpha1.Domain] = r
 	return doReconcile(ctx, req, new(ingressv1alpha1.Domain), controller)
-
-	// 	domain := new(ingressv1alpha1.Domain)
-	// 	if err := r.Get(ctx, req.NamespacedName, domain); err != nil {
-	// 		return ctrl.Result{}, client.IgnoreNotFound(err)
-	// 	}
-
-	// 	if isUpsert(domain) {
-	// 		if err := registerAndSyncFinalizer(ctx, r.Client, domain); err != nil {
-	// 			return ctrl.Result{}, err
-	// 		}
-	// 	} else {
-	// 		// The object is being deleted
-	// 		if hasFinalizer(domain) {
-	// 			if domain.Status.ID != "" {
-	// 				log.Info("Deleting reserved domain", "ID", domain.Status.ID)
-	// 				r.Recorder.Event(domain, v1.EventTypeNormal, "Deleting", fmt.Sprintf("Deleting Domain %s", domain.Name))
-	// 				// Question: Do we actually want to delete the reserved domains for real? Or maybe just delete the resource and have the user delete the reserved domain from
-	// 				// the ngrok dashboard manually?
-	// 				if err := r.DomainsClient.Delete(ctx, domain.Status.ID); err != nil {
-	// 					if !ngrok.IsNotFound(err) {
-	// 						r.Recorder.Event(domain, v1.EventTypeWarning, "FailedDelete", fmt.Sprintf("Failed to delete Domain %s: %s", domain.Name, err.Error()))
-	// 						return ctrl.Result{}, err
-	// 					}
-	// 					log.Info("Domain not found, assuming it was already deleted", "ID", domain.Status.ID)
-	// 				}
-	// 				domain.Status.ID = ""
-	// 			}
-
-	// 			if err := removeAndSyncFinalizer(ctx, r.Client, domain); err != nil {
-	// 				return ctrl.Result{}, err
-	// 			}
-	// 		}
-
-	// 		r.Recorder.Event(domain, v1.EventTypeNormal, "Deleted", fmt.Sprintf("Deleted Domain %s", domain.Name))
-
-	// 		// Stop reconciliation as the item is being deleted
-	// 		return ctrl.Result{}, nil
-	// 	}
-
-	// 	if domain.Status.ID != "" {
-	// 		if err := r.updateExternalResources(ctx, domain); err != nil {
-	// 			r.Recorder.Event(domain, v1.EventTypeWarning, "UpdateFailed", fmt.Sprintf("Failed to update Domain %s: %s", domain.Name, err.Error()))
-	// 			return ctrl.Result{}, err
-	// 		}
-	// 	} else {
-	// 		// Create
-	// 		if err := r.createExternalResources(ctx, domain); err != nil {
-	// 			r.Recorder.Event(domain, v1.EventTypeWarning, "CreateFailed", fmt.Sprintf("Failed to create Domain %s: %s", domain.Name, err.Error()))
-	// 			return ctrl.Result{}, err
-	// 		}
-
-	// 		r.Recorder.Event(domain, v1.EventTypeNormal, "Created", fmt.Sprintf("Created Domain %s", domain.Name))
-	// 	}
-
-	// return ctrl.Result{}, nil
+	// TODO event recording
 }
 
 func (r *DomainReconciler) client() client.Client {
 	return r.Client
+}
+
+func (r *DomainReconciler) getStatusID(domain *ingressv1alpha1.Domain) string {
+	return domain.Status.ID
 }
 
 func (r *DomainReconciler) create(ctx context.Context, domain *ingressv1alpha1.Domain) error {
@@ -186,61 +135,6 @@ func (r *DomainReconciler) update(ctx context.Context, domain *ingressv1alpha1.D
 
 func (r *DomainReconciler) delete(ctx context.Context, domain *ingressv1alpha1.Domain) error {
 	return r.DomainsClient.Delete(ctx, domain.Status.ID)
-}
-
-// Deletes the external resources associated with the ReservedDomain. This is just the reserved domain itself.
-//
-//nolint:unused
-func (r *DomainReconciler) deleteExternalResources(ctx context.Context, domain *ingressv1alpha1.Domain) error {
-	return r.DomainsClient.Delete(ctx, domain.Status.ID)
-}
-
-func (r *DomainReconciler) createExternalResources(ctx context.Context, domain *ingressv1alpha1.Domain) error {
-	// First check if the reserved domain already exists. The API is sometimes returning dangling CNAME records
-	// errors right now, so we'll check if the domain already exists before trying to create it.
-	resp, err := r.findReservedDomainByHostname(ctx, domain.Spec.Domain)
-	if err != nil {
-		return err
-	}
-
-	// Not found, so we'll create it
-	if resp == nil {
-		req := &ngrok.ReservedDomainCreate{
-			Domain:      domain.Spec.Domain,
-			Region:      domain.Spec.Region,
-			Description: domain.Spec.Description,
-			Metadata:    domain.Spec.Metadata,
-		}
-		resp, err = r.DomainsClient.Create(ctx, req)
-		if err != nil {
-			return err
-		}
-	}
-
-	return r.updateStatus(ctx, domain, resp)
-}
-
-func (r *DomainReconciler) updateExternalResources(ctx context.Context, domain *ingressv1alpha1.Domain) error {
-	resp, err := r.DomainsClient.Get(ctx, domain.Status.ID)
-	if err != nil {
-		return err
-	}
-
-	if !domain.Equal(resp) {
-		r.Log.Info("Updating reserved domain", "ID", domain.Status.ID)
-		req := &ngrok.ReservedDomainUpdate{
-			ID:          domain.Status.ID,
-			Description: &domain.Spec.Description,
-			Metadata:    &domain.Spec.Metadata,
-		}
-		resp, err = r.DomainsClient.Update(ctx, req)
-		if err != nil {
-			return err
-		}
-		return r.updateStatus(ctx, domain, resp)
-	}
-
-	return nil
 }
 
 // finds the reserved domain by the hostname. If it doesn't exist, returns nil

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -124,7 +124,6 @@ func (r *HTTPSEdgeReconciler) create(ctx context.Context, edge *ingressv1alpha1.
 			Hostports:   edge.Spec.Hostports,
 		})
 		if err != nil {
-			// TODO 7117
 			return err
 		}
 	}

--- a/internal/controllers/ingress_controller.go
+++ b/internal/controllers/ingress_controller.go
@@ -109,7 +109,7 @@ func (irec *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	if ingress.ObjectMeta.DeletionTimestamp.IsZero() {
+	if isUpsert(ingress) {
 		// The object is not being deleted, so register and sync finalizer
 		if err := registerAndSyncFinalizer(ctx, irec.Client, ingress); err != nil {
 			log.Error(err, "Failed to register finalizer")

--- a/internal/controllers/ippolicy_controller.go
+++ b/internal/controllers/ippolicy_controller.go
@@ -90,7 +90,7 @@ func (r *IPPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if policy.ObjectMeta.DeletionTimestamp.IsZero() {
+	if isUpsert(policy) {
 		if err := registerAndSyncFinalizer(ctx, r.Client, policy); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controllers/ippolicy_controller.go
+++ b/internal/controllers/ippolicy_controller.go
@@ -83,72 +83,32 @@ func (r *IPPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *IPPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("V1Alpha1IPPolicy", req.NamespacedName)
-
-	policy := new(ingressv1alpha1.IPPolicy)
-	if err := r.Get(ctx, req.NamespacedName, policy); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	if isUpsert(policy) {
-		if err := registerAndSyncFinalizer(ctx, r.Client, policy); err != nil {
-			return ctrl.Result{}, err
-		}
-	} else {
-		// The object is being deleted
-		if hasFinalizer(policy) {
-			if policy.Status.ID != "" {
-				log.Info("Deleting IP Policy", "ID", policy.Status.ID)
-				r.Recorder.Event(policy, v1.EventTypeNormal, "Deleting", fmt.Sprintf("Deleting policy %s", policy.Name))
-				if err := r.IPPoliciesClient.Delete(ctx, policy.Status.ID); err != nil {
-					if !ngrok.IsNotFound(err) {
-						r.Recorder.Event(policy, v1.EventTypeWarning, "FailedDelete", fmt.Sprintf("Failed to delete IPPolicy %s: %s", policy.Name, err.Error()))
-						return ctrl.Result{}, err
-					}
-					log.Info("Domain not found, assuming it was already deleted", "ID", policy.Status.ID)
-				}
-				policy.Status.ID = ""
-			}
-
-			if err := removeAndSyncFinalizer(ctx, r.Client, policy); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-
-		r.Recorder.Event(policy, v1.EventTypeNormal, "Deleted", fmt.Sprintf("Deleted IPPolicy %s", policy.Name))
-
-		// Stop reconciliation as the item is being deleted
-		return ctrl.Result{}, nil
-	}
-
-	if err := r.createOrUpdateIPPolicy(ctx, policy); err != nil {
-		return ctrl.Result{}, err
-	}
-	return ctrl.Result{}, r.createOrUpdateIPPolicyRules(ctx, policy)
+	var controller ngrokController[*ingressv1alpha1.IPPolicy] = r
+	return doReconcile(ctx, req, new(ingressv1alpha1.IPPolicy), controller)
+	// TODO events/logging
 }
 
-//nolint:unused
-func (r *IPPolicyReconciler) deleteRemoteResoures(ctx context.Context, policy *ingressv1alpha1.IPPolicy) error {
-	return r.IPPoliciesClient.Delete(ctx, policy.Status.ID)
+func (r *IPPolicyReconciler) client() client.Client {
+	return r.Client
 }
 
-func (r *IPPolicyReconciler) createOrUpdateIPPolicy(ctx context.Context, policy *ingressv1alpha1.IPPolicy) error {
-	if policy.Status.ID == "" {
-		r.Recorder.Event(policy, v1.EventTypeNormal, "Creating", fmt.Sprintf("Creating IPPolicy %s", policy.Name))
-		// Create the IP Policy since it doesn't exist
-		remotePolicy, err := r.IPPoliciesClient.Create(ctx, &ngrok.IPPolicyCreate{
-			Description: policy.Spec.Description,
-			Metadata:    policy.Spec.Metadata,
-		})
-		if err != nil {
-			return err
-		}
-		r.Recorder.Event(policy, v1.EventTypeNormal, "Created", fmt.Sprintf("Created IPPolicy %s", policy.Name))
-		policy.Status.ID = remotePolicy.ID
-		return r.Status().Update(ctx, policy)
-	}
+func (r *IPPolicyReconciler) getStatusID(policy *ingressv1alpha1.IPPolicy) string {
+	return policy.Status.ID
+}
 
-	// Update the IP Policy since it already exists
+func (r *IPPolicyReconciler) create(ctx context.Context, policy *ingressv1alpha1.IPPolicy) error {
+	remotePolicy, err := r.IPPoliciesClient.Create(ctx, &ngrok.IPPolicyCreate{
+		Description: policy.Spec.Description,
+		Metadata:    policy.Spec.Metadata,
+	})
+	if err != nil {
+		return err
+	}
+	policy.Status.ID = remotePolicy.ID
+	return r.Status().Update(ctx, policy)
+}
+
+func (r *IPPolicyReconciler) update(ctx context.Context, policy *ingressv1alpha1.IPPolicy) error {
 	remotePolicy, err := r.IPPoliciesClient.Get(ctx, policy.Status.ID)
 	if err != nil {
 		if ngrok.IsNotFound(err) {
@@ -172,6 +132,10 @@ func (r *IPPolicyReconciler) createOrUpdateIPPolicy(ctx context.Context, policy 
 	}
 
 	return nil
+}
+
+func (r *IPPolicyReconciler) delete(ctx context.Context, policy *ingressv1alpha1.IPPolicy) error {
+	return r.IPPoliciesClient.Delete(ctx, policy.Status.ID)
 }
 
 func (r *IPPolicyReconciler) createOrUpdateIPPolicyRules(ctx context.Context, policy *ingressv1alpha1.IPPolicy) error {

--- a/internal/controllers/tcpedge_controller.go
+++ b/internal/controllers/tcpedge_controller.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"reflect"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -82,52 +81,103 @@ func (r *TCPEdgeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.1/pkg/reconcile
 func (r *TCPEdgeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("V1Alpha1TCPEdge", req.NamespacedName)
+	var controller ngrokController[*ingressv1alpha1.TCPEdge] = r
+	return doReconcile(ctx, req, new(ingressv1alpha1.TCPEdge), controller)
+	// TODO events/logging
+}
 
-	edge := new(ingressv1alpha1.TCPEdge)
-	if err := r.Get(ctx, req.NamespacedName, edge); err != nil {
-		log.Error(err, "unable to fetch Edge")
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
+func (r *TCPEdgeReconciler) client() client.Client {
+	return r.Client
+}
 
-	if isUpsert(edge) {
-		if err := registerAndSyncFinalizer(ctx, r.Client, edge); err != nil {
-			return ctrl.Result{}, err
-		}
-	} else {
-		// The object is being deleted
-		if hasFinalizer(edge) {
-			if edge.Status.ID != "" {
-				r.Recorder.Event(edge, v1.EventTypeNormal, "Deleting", fmt.Sprintf("Deleting Edge %s", edge.Name))
-				if err := r.NgrokClientset.TCPEdges().Delete(ctx, edge.Status.ID); err != nil {
-					if !ngrok.IsNotFound(err) {
-						r.Recorder.Event(edge, v1.EventTypeWarning, "FailedDelete", fmt.Sprintf("Failed to delete Edge %s: %s", edge.Name, err.Error()))
-						return ctrl.Result{}, err
-					}
-				}
-				edge.Status.ID = ""
-			}
+func (r *TCPEdgeReconciler) getStatusID(edge *ingressv1alpha1.TCPEdge) string {
+	return edge.Status.ID
+}
 
-			if err := removeAndSyncFinalizer(ctx, r.Client, edge); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-
-		r.Recorder.Event(edge, v1.EventTypeNormal, "Deleted", fmt.Sprintf("Deleted Edge %s", edge.Name))
-		return ctrl.Result{}, nil
-	}
-
+func (r *TCPEdgeReconciler) create(ctx context.Context, edge *ingressv1alpha1.TCPEdge) error {
 	if err := r.reconcileTunnelGroupBackend(ctx, edge); err != nil {
-		log.Error(err, "unable to reconcile tunnel group backend", "backend.id", edge.Status.Backend.ID)
-		return ctrl.Result{}, err
+		return err
 	}
 
 	if err := r.reserveAddrIfEmpty(ctx, edge); err != nil {
-		log.Error(err, "unable to create tcp address")
-		return ctrl.Result{}, err
+		return err
 	}
 
-	return ctrl.Result{}, r.reconcileEdge(ctx, edge)
+	// Try to find the edge by the backend labels
+	resp, err := r.findEdgeByBackendLabels(ctx, edge.Spec.Backend.Labels)
+	if err != nil {
+		return err
+	}
+
+	if resp != nil {
+		return r.updateEdgeStatus(ctx, edge, resp)
+	}
+
+	// No edge has been created for this edge, create one
+	r.Log.Info("Creating new TCPEdge", "namespace", edge.Namespace, "name", edge.Name)
+	resp, err = r.NgrokClientset.TCPEdges().Create(ctx, &ngrok.TCPEdgeCreate{
+		Description: edge.Spec.Description,
+		Metadata:    edge.Spec.Metadata,
+		Backend: &ngrok.EndpointBackendMutate{
+			BackendID: edge.Status.Backend.ID,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	r.Log.Info("Created new TCPEdge", "edge.ID", resp.ID, "name", edge.Name, "namespace", edge.Namespace)
+
+	if err := r.updateEdgeStatus(ctx, edge, resp); err != nil {
+		return err
+	}
+
+	return r.updateIPRestrictionRouteModule(ctx, edge, resp)
+}
+
+func (r *TCPEdgeReconciler) update(ctx context.Context, edge *ingressv1alpha1.TCPEdge) error {
+	if err := r.reconcileTunnelGroupBackend(ctx, edge); err != nil {
+		return err
+	}
+
+	if err := r.reserveAddrIfEmpty(ctx, edge); err != nil {
+		return err
+	}
+
+	resp, err := r.NgrokClientset.TCPEdges().Get(ctx, edge.Status.ID)
+	if err != nil {
+		// If we can't find the edge in the ngrok API, it's been deleted, so clear the ID
+		// and requeue the edge. When it gets reconciled again, it will be recreated.
+		if ngrok.IsNotFound(err) {
+			r.Log.Info("TCPEdge not found, clearing ID and requeuing", "edge.ID", edge.Status.ID)
+			edge.Status.ID = ""
+			//nolint:errcheck
+			r.Status().Update(ctx, edge)
+		}
+		return err
+	}
+
+	// If the backend or hostports do not match, update the edge with the desired backend and hostports
+	if resp.Backend.Backend.ID != edge.Status.Backend.ID ||
+		!reflect.DeepEqual(resp.Hostports, edge.Status.Hostports) {
+		resp, err = r.NgrokClientset.TCPEdges().Update(ctx, &ngrok.TCPEdgeUpdate{
+			ID:          resp.ID,
+			Description: pointer.String(edge.Spec.Description),
+			Metadata:    pointer.String(edge.Spec.Metadata),
+			Hostports:   edge.Status.Hostports,
+			Backend: &ngrok.EndpointBackendMutate{
+				BackendID: edge.Status.Backend.ID,
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return r.updateEdgeStatus(ctx, edge, resp)
+}
+
+func (r *TCPEdgeReconciler) delete(ctx context.Context, edge *ingressv1alpha1.TCPEdge) error {
+	return r.NgrokClientset.TCPEdges().Delete(ctx, edge.Status.ID)
 }
 
 func (r *TCPEdgeReconciler) reconcileTunnelGroupBackend(ctx context.Context, edge *ingressv1alpha1.TCPEdge) error {
@@ -173,74 +223,6 @@ func (r *TCPEdgeReconciler) reconcileTunnelGroupBackend(ctx context.Context, edg
 	edge.Status.Backend.ID = backend.ID
 
 	return r.Status().Update(ctx, edge)
-}
-
-func (r *TCPEdgeReconciler) reconcileEdge(ctx context.Context, edge *ingressv1alpha1.TCPEdge) error {
-	if edge.Status.ID != "" {
-		// An edge already exists, make sure everything matches
-		resp, err := r.NgrokClientset.TCPEdges().Get(ctx, edge.Status.ID)
-		if err != nil {
-			// If we can't find the edge in the ngrok API, it's been deleted, so clear the ID
-			// and requeue the edge. When it gets reconciled again, it will be recreated.
-			if ngrok.IsNotFound(err) {
-				r.Log.Info("TCPEdge not found, clearing ID and requeuing", "edge.ID", edge.Status.ID)
-				edge.Status.ID = ""
-				//nolint:errcheck
-				r.Status().Update(ctx, edge)
-			}
-			return err
-		}
-
-		// If the backend or hostports do not match, update the edge with the desired backend and hostports
-		if resp.Backend.Backend.ID != edge.Status.Backend.ID ||
-			!reflect.DeepEqual(resp.Hostports, edge.Status.Hostports) {
-			resp, err = r.NgrokClientset.TCPEdges().Update(ctx, &ngrok.TCPEdgeUpdate{
-				ID:          resp.ID,
-				Description: pointer.String(edge.Spec.Description),
-				Metadata:    pointer.String(edge.Spec.Metadata),
-				Hostports:   edge.Status.Hostports,
-				Backend: &ngrok.EndpointBackendMutate{
-					BackendID: edge.Status.Backend.ID,
-				},
-			})
-			if err != nil {
-				return err
-			}
-		}
-
-		return r.updateEdgeStatus(ctx, edge, resp)
-	}
-
-	// Try to find the edge by the backend labels
-	resp, err := r.findEdgeByBackendLabels(ctx, edge.Spec.Backend.Labels)
-	if err != nil {
-		return err
-	}
-
-	if resp != nil {
-		return r.updateEdgeStatus(ctx, edge, resp)
-	}
-
-	// No edge has been created for this edge, create one
-	r.Log.Info("Creating new TCPEdge", "namespace", edge.Namespace, "name", edge.Name)
-	resp, err = r.NgrokClientset.TCPEdges().Create(ctx, &ngrok.TCPEdgeCreate{
-		Description: edge.Spec.Description,
-		Metadata:    edge.Spec.Metadata,
-		Backend: &ngrok.EndpointBackendMutate{
-			BackendID: edge.Status.Backend.ID,
-		},
-	})
-	if err != nil {
-		return err
-	}
-	r.Log.Info("Created new TCPEdge", "edge.ID", resp.ID, "name", edge.Name, "namespace", edge.Namespace)
-
-	if err := r.updateEdgeStatus(ctx, edge, resp); err != nil {
-		return err
-	}
-
-	return r.updateIPRestrictionRouteModule(ctx, edge, resp)
-
 }
 
 func (r *TCPEdgeReconciler) findEdgeByBackendLabels(ctx context.Context, backendLabels map[string]string) (*ngrok.TCPEdge, error) {

--- a/internal/controllers/tcpedge_controller.go
+++ b/internal/controllers/tcpedge_controller.go
@@ -90,7 +90,7 @@ func (r *TCPEdgeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if edge.ObjectMeta.DeletionTimestamp.IsZero() {
+	if isUpsert(edge) {
 		if err := registerAndSyncFinalizer(ctx, r.Client, edge); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controllers/tunnel_controller.go
+++ b/internal/controllers/tunnel_controller.go
@@ -66,8 +66,9 @@ func (r *TunnelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Log:      r.Log,
 		Recorder: r.Recorder,
 
-		update: r.update,
-		delete: r.delete,
+		kubeType: "v1alpha1.Tunnel",
+		update:   r.update,
+		delete:   r.delete,
 	}
 
 	cont, err := controller.NewUnmanaged("tunnel-controller", mgr, controller.Options{
@@ -104,7 +105,6 @@ func (r *TunnelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.1/pkg/reconcile
 func (r *TunnelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	return r.controller.reconcile(ctx, req, new(ingressv1alpha1.Tunnel))
-	// TODO events/logging
 }
 
 func (r *TunnelReconciler) update(ctx context.Context, tunnel *ingressv1alpha1.Tunnel) error {

--- a/internal/controllers/tunnel_controller.go
+++ b/internal/controllers/tunnel_controller.go
@@ -104,7 +104,7 @@ func (r *TunnelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	tunnelName := req.NamespacedName.String()
 
-	if isDelete(tunnel.ObjectMeta) {
+	if isDelete(tunnel) {
 		r.Recorder.Event(tunnel, v1.EventTypeNormal, "Deleting", fmt.Sprintf("Deleting tunnel %s", tunnelName))
 		err := r.TunnelDriver.DeleteTunnel(ctx, tunnelName)
 		if err != nil {

--- a/internal/controllers/utils.go
+++ b/internal/controllers/utils.go
@@ -2,18 +2,12 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 	"strings"
-	"time"
 
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/v1alpha1"
-	ierr "github.com/ngrok/kubernetes-ingress-controller/internal/errors"
-	"github.com/ngrok/ngrok-api-go/v5"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -53,28 +47,6 @@ func registerAndSyncFinalizer(ctx context.Context, c client.Writer, o client.Obj
 func removeAndSyncFinalizer(ctx context.Context, c client.Writer, o client.Object) error {
 	removeFinalizer(o)
 	return c.Update(ctx, o)
-}
-
-func ngrokControllerError(err error, retryCodes ...int) (ctrl.Result, error) {
-	if errors.As(err, &ierr.ErrInvalidConfiguration{}) {
-		return ctrl.Result{Requeue: false}, nil
-	}
-
-	var nerr *ngrok.Error
-	if errors.As(err, &nerr) {
-		switch {
-		case nerr.StatusCode >= 500:
-			return ctrl.Result{Requeue: true}, err
-		case nerr.StatusCode == http.StatusTooManyRequests:
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute}, nil
-		case ngrok.IsErrorCode(err, retryCodes...):
-			return ctrl.Result{Requeue: true}, nil
-		default:
-			return ctrl.Result{Requeue: false}, nil
-		}
-	}
-
-	return ctrl.Result{Requeue: true}, err
 }
 
 type ipPolicyResolver struct {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,11 +1,9 @@
 package errors
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/ngrok/ngrok-api-go/v5"
 	netv1 "k8s.io/api/networking/v1"
 )
 
@@ -152,21 +150,4 @@ func (e ErrInvalidConfiguration) Error() string {
 
 func (e ErrInvalidConfiguration) Unwrap() error {
 	return e.cause
-}
-
-func IsErrorReconcilable(err error) bool {
-	if err == nil {
-		return true
-	}
-
-	if errors.As(err, &ErrInvalidConfiguration{}) {
-		return false
-	}
-
-	var nerr *ngrok.Error
-	if errors.As(err, &nerr) {
-		return nerr.StatusCode >= 500
-	}
-
-	return true
 }


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #283 

## What
Currently, the controllers don't (most of them) inspect the errors coming from the ngrok API and retry forever. With this PR, we'll look at the resulting error, and retry based on the error codes coming from the ngrok API:
 * server errors will be retried
 * rate limit errors will be retried with 1m backoff
 * controller specific errors are retried depending on the controller. Only the `HTTPSEdge` controller is currently retrying, specifically for the case where the domain for this edge wasn't found (which allows the domain controller to register it concurrently) 

## How
 * extract common controller functionality into the `baseController`
 * the `baseController` provides standardized error checking that can be customized by the concrete controller.

## Breaking Changes
None
