### PR TITLE
Reconciling ngrok-module-set changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -timeout 20s
 
 ##@ Build
 

--- a/internal/controllers/moduleset_controller.go
+++ b/internal/controllers/moduleset_controller.go
@@ -33,7 +33,7 @@ func (r *ModuleSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // This reconcile function is called by the controller-runtime manager.
 // It is invoked whenever there is an event that occurs for a resource
 // being watched (in our case, NgrokModuleSets). If you tail the controller
-// logs and delete, update, edit ingress objects, you see the events come in.
+// logs and delete, update, edit ngrokmoduleset objects, you see the events come in.
 func (r *ModuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	err := r.Driver.SyncEdges(ctx, r.Client)
 	return ctrl.Result{}, err

--- a/internal/controllers/moduleset_controller.go
+++ b/internal/controllers/moduleset_controller.go
@@ -35,6 +35,6 @@ func (r *ModuleSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // being watched (in our case, NgrokModuleSets). If you tail the controller
 // logs and delete, update, edit ingress objects, you see the events come in.
 func (r *ModuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	err := r.Driver.Sync(ctx, r.Client)
+	err := r.Driver.SyncEdges(ctx, r.Client)
 	return ctrl.Result{}, err
 }

--- a/internal/controllers/moduleset_controller.go
+++ b/internal/controllers/moduleset_controller.go
@@ -1,0 +1,40 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/v1alpha1"
+	"github.com/ngrok/kubernetes-ingress-controller/internal/store"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ModuleSetReconciler struct {
+	client.Client
+
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+	Driver   *store.Driver
+}
+
+func (r *ModuleSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&ingressv1alpha1.NgrokModuleSet{}).
+		WithEventFilter(commonPredicateFilters).
+		Complete(r)
+}
+
+// +kubebuilder:rbac:groups=ingress.k8s.ngrok.com,resources=ngrokmodulesets,verbs=get;list;watch
+
+// This reconcile function is called by the controller-runtime manager.
+// It is invoked whenever there is an event that occurs for a resource
+// being watched (in our case, NgrokModuleSets). If you tail the controller
+// logs and delete, update, edit ingress objects, you see the events come in.
+func (r *ModuleSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	err := r.Driver.Sync(ctx, r.Client)
+	return ctrl.Result{}, err
+}

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -197,7 +197,11 @@ func (d *Driver) DeleteNamedIngress(n types.NamespacedName) error {
 	return d.cacheStores.Delete(ingress)
 }
 
-// syncStart will let the first caller proceed, but then will batch further calls to the last one
+// syncStart will:
+//   - let the first caller proceed, indicated by returning true
+//   - while the first one is running any subsequent calls will be batched to the last call
+//   - the callers between first and last will be assumed "success" and wait will return nil
+//   - the last one will return an error, which will retrigger reconciliation
 func (d *Driver) syncStart(partial bool) (bool, func(ctx context.Context) error) {
 	d.log.Info("sync start")
 	d.syncMu.Lock()

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -253,10 +253,17 @@ func (d *Driver) Sync(ctx context.Context, c client.Client) error {
 		return err
 	}
 
-	return d.updateIngressStatuses(ctx, c)
+	if err := d.updateIngressStatuses(ctx, c); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (d *Driver) SyncEdges(ctx context.Context, c client.Client) error {
+	if !d.allowConcurrentSync {
+	}
+
 	d.log.Info("syncing edges state!!")
 
 	desiredEdges := d.calculateHTTPSEdges()
@@ -269,7 +276,11 @@ func (d *Driver) SyncEdges(ctx context.Context, c client.Client) error {
 		return err
 	}
 
-	return d.applyHTTPSEdges(ctx, c, desiredEdges, currEdges.Items)
+	if err := d.applyHTTPSEdges(ctx, c, desiredEdges, currEdges.Items); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (d *Driver) applyDomains(ctx context.Context, c client.Client, desiredDomains, currentDomains []ingressv1alpha1.Domain) error {

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -152,6 +152,27 @@ func (d *Driver) Seed(ctx context.Context, c client.Reader) error {
 	return nil
 }
 
+func (d *Driver) PrintState(setupLog logr.Logger) {
+	ings := d.store.ListNgrokIngressesV1()
+	for _, ing := range ings {
+		setupLog.Info("found matching ingress", "ingress-name", ing.Name, "ingress-namespace", ing.Namespace)
+	}
+
+	// Helpful debug information if someone doesn't have their ingress class set up correctly.
+	if len(ings) == 0 {
+		ingresses := d.store.ListIngressesV1()
+		ngrokIngresses := d.store.ListNgrokIngressesV1()
+		ingressClasses := d.store.ListIngressClassesV1()
+		ngrokIngressClasses := d.store.ListNgrokIngressClassesV1()
+		setupLog.Info("no matching ingresses found",
+			"all ingresses", ingresses,
+			"all ngrok ingresses", ngrokIngresses,
+			"all ingress classes", ingressClasses,
+			"all ngrok ingress classes", ngrokIngressClasses,
+		)
+	}
+}
+
 func (d *Driver) UpdateIngress(ingress *netv1.Ingress) (*netv1.Ingress, error) {
 	if err := d.store.Update(ingress); err != nil {
 		return nil, err

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -230,7 +230,7 @@ func (d *Driver) syncStart(partial bool) (bool, func(ctx context.Context) error)
 	}
 
 	// put yourself in waiting position
-	ch := make(chan error)
+	ch := make(chan error, 1)
 	if partial {
 		d.syncPartialCh = ch
 	} else {
@@ -248,18 +248,20 @@ func (d *Driver) syncStart(partial bool) (bool, func(ctx context.Context) error)
 	}
 }
 
+var errSyncDone = errors.New("sync done")
+
 func (d *Driver) syncDone() {
 	d.log.Info("sync done")
 	d.syncMu.Lock()
 	defer d.syncMu.Unlock()
 
 	if d.syncFullCh != nil {
-		d.syncFullCh <- fmt.Errorf("sync done")
+		d.syncFullCh <- errSyncDone
 		close(d.syncFullCh)
 		d.syncFullCh = nil
 	}
 	if d.syncPartialCh != nil {
-		d.syncPartialCh <- fmt.Errorf("sync done")
+		d.syncPartialCh <- errSyncDone
 		close(d.syncPartialCh)
 		d.syncPartialCh = nil
 	}

--- a/internal/store/driver_test.go
+++ b/internal/store/driver_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Driver", func() {
 		driver = NewDriver(logger, scheme, defaultControllerName, types.NamespacedName{
 			Name: defaultManagerName,
 		})
-		driver.allowConcurrentSync = true
+		driver.syncAllowConcurrent = true
 	})
 
 	Describe("Seed", func() {

--- a/internal/store/driver_test.go
+++ b/internal/store/driver_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Driver", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, obj := range obs {
-				foundObj, found, err := driver.Get(obj)
+				foundObj, found, err := driver.store.Get(obj)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(foundObj).ToNot(BeNil())
@@ -73,13 +73,13 @@ var _ = Describe("Driver", func() {
 			err := driver.Seed(context.Background(), c)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = driver.DeleteIngress(types.NamespacedName{
+			err = driver.DeleteNamedIngress(types.NamespacedName{
 				Namespace: "test-namespace",
 				Name:      "test-ingress",
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			foundObj, found, err := driver.Get(&i1)
+			foundObj, found, err := driver.store.Get(&i1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeFalse())
 			Expect(foundObj).To(BeNil())
@@ -120,7 +120,7 @@ var _ = Describe("Driver", func() {
 				c := fake.NewFakeClientWithScheme(scheme, obs...)
 
 				for _, obj := range obs {
-					err := driver.Update(obj)
+					err := driver.store.Update(obj)
 					Expect(err).ToNot(HaveOccurred())
 				}
 				err := driver.Seed(context.Background(), c)
@@ -372,14 +372,14 @@ var _ = Describe("Driver", func() {
 					},
 				},
 			}
-			driver.Add(ms1)
-			driver.Add(ms2)
-			driver.Add(ms3)
+			driver.store.Add(ms1)
+			driver.store.Add(ms2)
+			driver.store.Add(ms3)
 		})
 
 		It("Should return an empty module set if the ingress has no modules annotaion", func() {
 			ing := NewTestIngressV1("test-ingress", "test")
-			Expect(driver.Add(&ing)).To(BeNil())
+			Expect(driver.store.Add(&ing)).To(BeNil())
 
 			ms, err := driver.getNgrokModuleSetForIngress(&ing)
 			Expect(err).To(BeNil())
@@ -393,7 +393,7 @@ var _ = Describe("Driver", func() {
 		It("Should return the matching module set if the ingress has a modules annotaion", func() {
 			ing := NewTestIngressV1("test-ingress", "test")
 			ing.SetAnnotations(map[string]string{"k8s.ngrok.com/modules": "ms1"})
-			Expect(driver.Add(&ing)).To(BeNil())
+			Expect(driver.store.Add(&ing)).To(BeNil())
 
 			ms, err := driver.getNgrokModuleSetForIngress(&ing)
 			Expect(err).To(BeNil())
@@ -403,7 +403,7 @@ var _ = Describe("Driver", func() {
 		It("merges modules with the last one winning if multiple module sets are specified", func() {
 			ing := NewTestIngressV1("test-ingress", "test")
 			ing.SetAnnotations(map[string]string{"k8s.ngrok.com/modules": "ms1,ms2,ms3"})
-			Expect(driver.Add(&ing)).To(BeNil())
+			Expect(driver.store.Add(&ing)).To(BeNil())
 
 			ms, err := driver.getNgrokModuleSetForIngress(&ing)
 			Expect(err).To(BeNil())

--- a/internal/store/driver_test.go
+++ b/internal/store/driver_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Driver", func() {
 		driver = NewDriver(logger, scheme, defaultControllerName, types.NamespacedName{
 			Name: defaultManagerName,
 		})
-		driver.bypassReentranceCheck = true
+		driver.allowConcurrentSync = true
 	})
 
 	Describe("Seed", func() {

--- a/internal/store/updatestorehandler.go
+++ b/internal/store/updatestorehandler.go
@@ -16,21 +16,21 @@ var _ handler.EventHandler = &UpdateStoreHandler{}
 // It is used to simply watch some resources and keep their values updated in the store.
 // It is used to keep various crds like edges/tunnels/domains, and core resources like ingress classes, updated.
 type UpdateStoreHandler struct {
-	driver *Driver
-	log    logr.Logger
+	store Storer
+	log   logr.Logger
 }
 
 // NewUpdateStoreHandler creates a new UpdateStoreHandler
 func NewUpdateStoreHandler(resourceName string, d *Driver) *UpdateStoreHandler {
 	return &UpdateStoreHandler{
-		driver: d,
-		log:    d.log.WithValues("UpdateStoreHandlerFor", resourceName),
+		store: d.store,
+		log:   d.log.WithValues("UpdateStoreHandlerFor", resourceName),
 	}
 }
 
 // Create is called in response to an create event - e.g. Edge Creation.
 func (e *UpdateStoreHandler) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
-	if err := e.driver.Update(evt.Object); err != nil {
+	if err := e.store.Update(evt.Object); err != nil {
 		e.log.Error(err, "error updating object in create", "object", evt.Object)
 		return
 	}
@@ -38,7 +38,7 @@ func (e *UpdateStoreHandler) Create(evt event.CreateEvent, q workqueue.RateLimit
 
 // Update is called in response to an update event -  e.g. Edge Updated.
 func (e *UpdateStoreHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	if err := e.driver.Update(evt.ObjectNew); err != nil {
+	if err := e.store.Update(evt.ObjectNew); err != nil {
 		e.log.Error(err, "error updating object in update", "object", evt.ObjectNew)
 		return
 	}
@@ -46,7 +46,7 @@ func (e *UpdateStoreHandler) Update(evt event.UpdateEvent, q workqueue.RateLimit
 
 // Delete is called in response to a delete event - e.g. Edge Deleted.
 func (e *UpdateStoreHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
-	if err := e.driver.Delete(evt.Object); err != nil {
+	if err := e.store.Delete(evt.Object); err != nil {
 		e.log.Error(err, "error deleting object", "object", evt.Object)
 		return
 	}
@@ -55,7 +55,7 @@ func (e *UpdateStoreHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimit
 // Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
 // external trigger request
 func (e *UpdateStoreHandler) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
-	if err := e.driver.Update(evt.Object); err != nil {
+	if err := e.store.Update(evt.Object); err != nil {
 		e.log.Error(err, "error updating object in generic", "object", evt.Object)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -243,6 +243,16 @@ func runController(ctx context.Context, opts managerOpts) error {
 		setupLog.Error(err, "unable to create controller", "controller", "IPPolicy")
 		os.Exit(1)
 	}
+	if err = (&controllers.ModuleSetReconciler{
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("ngrok-module-set"),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("ngrok-module-set-controller"),
+		Driver:   driver,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "NgrokModuleSet")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/main.go
+++ b/main.go
@@ -297,24 +297,7 @@ func getDriver(ctx context.Context, mgr manager.Manager, options managerOpts) (*
 		return nil, fmt.Errorf("unable to seed cache store: %w", err)
 	}
 
-	ings := d.ListNgrokIngressesV1()
-	for _, ing := range ings {
-		setupLog.Info("found matching ingress", "ingress-name", ing.Name, "ingress-namespace", ing.Namespace)
-	}
-
-	// Helpful debug information if someone doesn't have their ingress class set up correctly.
-	if len(ings) == 0 {
-		ingresses := d.ListIngressesV1()
-		ngrokIngresses := d.ListNgrokIngressesV1()
-		ingressClasses := d.ListIngressClassesV1()
-		ngrokIngressClasses := d.ListNgrokIngressClassesV1()
-		setupLog.Info("no matching ingresses found",
-			"all ingresses", ingresses,
-			"all ngrok ingresses", ngrokIngresses,
-			"all ingress classes", ingressClasses,
-			"all ngrok ingress classes", ngrokIngressClasses,
-		)
-	}
+	d.PrintState(setupLog)
 
 	return d, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #287

## What
Currently, the controller watches for changes in `NgrokModuleSet` CRs (and persists the updates), but it is not actively triggering reconciliation when they change. This means that changes only in modules are not applied to the `HTTPSEdge` CRs when the `NgrokModuleSet` CRs referenced by an `Ingress` get changed.

Once this PR merges, both `Ingress` and `NgrokModuleSet` will trigger reconciliation and will keep dependent objects up to date.

## How
 * Add another controller that owns and watches `NgrokModuleSet`s
 * Trigger partial reconciliation, since only `HTTPSEdges` are affected by modules
 * Make sure we are not doing too many changes, since both `Sync` methods might run concurrently

## Breaking Changes
None
