### PR TITLE
Add an ingress uid label to tunnels

### DIFF
--- a/helm/ingress-controller/Chart.lock
+++ b/helm/ingress-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.6.0
-digest: sha256:6657a16696e9c132a98eb257951876f491f213b55aac7b4894993d260b2bae09
-generated: "2023-07-13T14:02:39.574375-04:00"
+  version: 2.8.0
+digest: sha256:83dc5879aedee09c5d5d1865ed9e861feeeea6df10e56c41787911b54e141af9
+generated: "2023-08-18T09:47:25.793815648-04:00"

--- a/internal/controllers/base_controller.go
+++ b/internal/controllers/base_controller.go
@@ -73,7 +73,7 @@ func (r *baseController[T]) reconcile(ctx context.Context, req ctrl.Request, cr 
 		}
 	} else {
 		if hasFinalizer(cr) {
-			if r.statusID == nil || r.statusID(cr) != "" {
+			if r.statusID != nil && r.statusID(cr) != "" {
 				sid := r.statusID(cr)
 				r.Recorder.Event(cr, v1.EventTypeNormal, "Deleting", fmt.Sprintf("Deleting %s: %s", r.kubeType, crName))
 				if err := r.delete(ctx, cr); err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Resolves #291

## What

Add a `k8s.ngrok.com/ingress-uid` label to tunnels created by the
ingress controller to uniquely identify them among multiple ingress
controller instances.

## How

Plumb the full ingress object down to the method to create ngrok tunnel
lables, and add the UID from that. The ingress UID should be stable as
long as the object exists in k8s (citation needed?), so we don't have to
worry about unexpected recreate thrashing as a result of it changing.

## Breaking Changes

Shouldn't be any. After the ingress controller is redeployed, a
difference should be detected between the desired and actual tunnel
state, and things should be recreated with the new labels as expected.
