### PR TITLE
*: reflect.DeepEqual -> maps/slices.Equal

### DIFF
--- a/api/v1alpha1/httpsedge_types.go
+++ b/api/v1alpha1/httpsedge_types.go
@@ -25,9 +25,8 @@ SOFTWARE.
 package v1alpha1
 
 import (
-	"reflect"
-
 	"github.com/ngrok/ngrok-api-go/v5"
+	"golang.org/x/exp/slices"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -161,7 +160,7 @@ func (e *HTTPSEdge) Equal(edge *ngrok.HTTPSEdge) bool {
 	}
 
 	// check if the hostports match
-	if !reflect.DeepEqual(e.Spec.Hostports, edge.Hostports) {
+	if !slices.Equal(e.Spec.Hostports, edge.Hostports) {
 		return false
 	}
 

--- a/internal/controllers/httpsedge_controller.go
+++ b/internal/controllers/httpsedge_controller.go
@@ -30,6 +30,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -481,7 +483,7 @@ func (r *tunnelGroupBackendReconciler) findOrCreate(ctx context.Context, backend
 	log.V(3).Info("Searching for tunnel group backend with matching labels")
 	for _, b := range r.backends {
 		// The labels match, so we can use this backend
-		if reflect.DeepEqual(b.Labels, backend.Labels) {
+		if maps.Equal(b.Labels, backend.Labels) {
 			log.V(3).Info("Found matching tunnel group backend", "id", b.ID)
 			return b, nil
 		}
@@ -638,7 +640,7 @@ func (u *edgeRouteModuleUpdater) setEdgeRouteIPRestriction(ctx context.Context, 
 		}
 	}
 
-	if reflect.DeepEqual(remoteIPPolicies, policyIds) {
+	if slices.Equal(remoteIPPolicies, policyIds) {
 		u.logMatches(log, "IP Restriction", routeModuleComparisonDeepEqual)
 		return nil
 	}

--- a/internal/controllers/tcpedge_controller.go
+++ b/internal/controllers/tcpedge_controller.go
@@ -27,8 +27,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"reflect"
 
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -162,7 +163,7 @@ func (r *TCPEdgeReconciler) update(ctx context.Context, edge *ingressv1alpha1.TC
 
 	// If the backend or hostports do not match, update the edge with the desired backend and hostports
 	if resp.Backend.Backend.ID != edge.Status.Backend.ID ||
-		!reflect.DeepEqual(resp.Hostports, edge.Status.Hostports) {
+		!slices.Equal(resp.Hostports, edge.Status.Hostports) {
 		resp, err = r.NgrokClientset.TCPEdges().Update(ctx, &ngrok.TCPEdgeUpdate{
 			ID:          resp.ID,
 			Description: pointer.String(edge.Spec.Description),
@@ -205,7 +206,7 @@ func (r *TCPEdgeReconciler) reconcileTunnelGroupBackend(ctx context.Context, edg
 		}
 
 		// If the labels don't match, update the backend with the desired labels
-		if !reflect.DeepEqual(backend.Labels, specBackend.Labels) {
+		if !maps.Equal(backend.Labels, specBackend.Labels) {
 			_, err = r.NgrokClientset.TunnelGroupBackends().Update(ctx, &ngrok.TunnelGroupBackendUpdate{
 				ID:          backend.ID,
 				Metadata:    pointer.String(specBackend.Metadata),
@@ -252,7 +253,7 @@ func (r *TCPEdgeReconciler) findEdgeByBackendLabels(ctx context.Context, backend
 			continue
 		}
 
-		if reflect.DeepEqual(backend.Labels, backendLabels) {
+		if maps.Equal(backend.Labels, backendLabels) {
 			r.Log.Info("Found existing TCPEdge with matching backend labels", "labels", backendLabels, "edge.ID", edge.ID)
 			return edge, nil
 		}

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -272,7 +272,7 @@ func (d *Driver) Sync(ctx context.Context, c client.Client) error {
 			needsUpdate := false
 
 			// compare/update owner references
-			if !reflect.DeepEqual(desiredTunnel.OwnerReferences, currTunnel.OwnerReferences) {
+			if !slices.Equal(desiredTunnel.OwnerReferences, currTunnel.OwnerReferences) {
 				needsUpdate = true
 				currTunnel.OwnerReferences = desiredTunnel.OwnerReferences
 			}

--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -9,11 +9,11 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"reflect"
 
 	"github.com/go-logr/logr"
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/v1alpha1"
 	"github.com/ngrok/kubernetes-ingress-controller/internal/version"
+	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -127,7 +127,7 @@ func (td *TunnelDriver) CreateTunnel(ctx context.Context, name string, labels ma
 	log := log.FromContext(ctx)
 
 	if tun, ok := td.tunnels[name]; ok {
-		if reflect.DeepEqual(tun.Labels(), labels) {
+		if maps.Equal(tun.Labels(), labels) {
 			log.Info("Tunnel labels match existing tunnel, doing nothing")
 			return nil
 		}


### PR DESCRIPTION
We have generics, we can do faster and better equality comparing in a few places.

These should be functionality identical. This is meant to be a rote refactor that the type-system covers, and no additional validation beyond that was done.