### PR TITLE
do no check env in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,7 @@ jobs:
       run: make docker-build
 
     - name: Deploy controller to local cluster
-      run: make deploy
+      run: make _deploy # do not check env vars
 
     - name: Check if controller is up
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,7 @@ jobs:
       run: make docker-build
 
     - name: Deploy controller to local cluster
-      run: make _deploy # do not check env vars
+      run: make deploy NGROK_API_KEY=fake-ci-key NGROK_AUTHTOKEN=fake-ci-token
 
     - name: Check if controller is up
       run: |

--- a/Makefile
+++ b/Makefile
@@ -115,19 +115,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: _deploy-check-env-vars _deploy ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-
-.PHONY: _deploy-check-env-vars
-_deploy-check-env-vars:
-ifndef NGROK_API_KEY
-	$(error An NGROK_API_KEY must be set)
-endif
-ifndef NGROK_AUTHTOKEN
-	$(error An NGROK_AUTHTOKEN must be set)
-endif
-
-.PHONY: _deploy
-_deploy: docker-build manifests kustomize _helm_setup ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: _deploy-check-env-vars docker-build manifests kustomize _helm_setup ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	helm upgrade ngrok-ingress-controller $(HELM_CHART_DIR) --install \
 		--namespace ngrok-ingress-controller \
 		--create-namespace \
@@ -141,6 +129,15 @@ _deploy: docker-build manifests kustomize _helm_setup ## Deploy controller to th
 		--set log.stacktraceLevel=panic \
 		--set metaData.env=local,metaData.from=makefile && \
 	kubectl rollout restart deployment ngrok-ingress-controller-kubernetes-ingress-controller-manager -n ngrok-ingress-controller
+
+.PHONY: _deploy-check-env-vars
+_deploy-check-env-vars:
+ifndef NGROK_API_KEY
+	$(error An NGROK_API_KEY must be set)
+endif
+ifndef NGROK_AUTHTOKEN
+	$(error An NGROK_AUTHTOKEN must be set)
+endif
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,19 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: _deploy-check-env-vars docker-build manifests kustomize _helm_setup ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: _deploy-check-env-vars _deploy ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+
+.PHONY: _deploy-check-env-vars
+_deploy-check-env-vars:
+ifndef NGROK_API_KEY
+	$(error An NGROK_API_KEY must be set)
+endif
+ifndef NGROK_AUTHTOKEN
+	$(error An NGROK_AUTHTOKEN must be set)
+endif
+
+.PHONY: _deploy
+_deploy: docker-build manifests kustomize _helm_setup ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	helm upgrade ngrok-ingress-controller $(HELM_CHART_DIR) --install \
 		--namespace ngrok-ingress-controller \
 		--create-namespace \
@@ -129,16 +141,6 @@ deploy: _deploy-check-env-vars docker-build manifests kustomize _helm_setup ## D
 		--set log.stacktraceLevel=panic \
 		--set metaData.env=local,metaData.from=makefile && \
 	kubectl rollout restart deployment ngrok-ingress-controller-kubernetes-ingress-controller-manager -n ngrok-ingress-controller
-
-.PHONY: _deploy-check-env-vars
-_deploy-check-env-vars:
-ifndef NGROK_API_KEY
-	$(error An NGROK_API_KEY must be set)
-endif
-ifndef NGROK_AUTHTOKEN
-	$(error An NGROK_AUTHTOKEN must be set)
-endif
-
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
We introduced a change that requires `NGROK_AUTHTOKEN` and `NGROK_API_KEY` vars to be set on deploy, which is useful when doing manual deploys. However, in CI we use the same, but just to see if we can deploy successfully, without actually using the values for these vars. In this case, the ci build fails, since it checks these vars as part of the `make deploy` run.

## How
Split `deploy` cmd/script to two parts, and use the one that doesn't check in CI.

## Breaking Changes
None
