### PR TITLE
Use service UID instead of ingress UID for tunnel labels

### DIFF
--- a/helm/ingress-controller/Chart.lock
+++ b/helm/ingress-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.9.1
-digest: sha256:7a12a2846de36d331913c69e1ad04a1de21dcbf20b8c6a3f628dcd15b637002c
-generated: "2023-08-30T18:01:50.92535935-04:00"
+  version: 2.10.0
+digest: sha256:dde2dd8a6a067dc19ae9ea30781c145654a2f8663664497c60b7deec6825f440
+generated: "2023-09-07T11:46:40.831614-04:00"


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #291 

## What
With #293 we introduced a change that allow controllers deployed to multiple clusters to correctly identify https edges and tunnel (think of multiple devs running the same app in k8s on their own machines). However, because we used the ingress UID, we broke the case where the same service is used in multiple ingresses in the same namespace - essentially one of them will set the tunnel labels to its own and the rest will be un-routable. Here, we move to use a different identifier, e.g. service UID, with the premise that these are uniquely *enough* (both across the cluster and between clusters).

## How
Extract the service UID and use it to set the https edge/tunnel labels.

## Breaking Changes
None
