### PR TITLE
Remove port portion from destination to present FQDN as SNI

### DIFF
--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -225,7 +225,7 @@ func handleConn(ctx context.Context, dest string, protocol string, dialer Dialer
 	if protocol == "HTTPS" {
 		host, _, err := net.SplitHostPort(dest)
 		if err != nil {
-			return err
+			host = dest
 		}
 		next = tls.Client(next, &tls.Config{
 			ServerName:         host,

--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -223,8 +223,12 @@ func handleConn(ctx context.Context, dest string, protocol string, dialer Dialer
 
 	// Support HTTPS backends
 	if protocol == "HTTPS" {
+		host, _, err := net.SplitHostPort(dest)
+		if err != nil {
+			return err
+		}
 		next = tls.Client(next, &tls.Config{
-			ServerName:         dest,
+			ServerName:         host,
 			InsecureSkipVerify: true,
 		})
 	}


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
When forwarding TLS connection, we are setting the `ServerName`/SNI to the target. According to RFC 6066:
```
"HostName" contains the fully qualified DNS hostname of the server,
   as understood by the client.  The hostname is represented as a byte
   string using ASCII encoding without a trailing dot.  This allows the
   support of internationalized domain names through the use of A-labels
   defined in [RFC5890].  DNS hostnames are case-insensitive.  The
   algorithm to compare hostnames is described in [RFC5890], Section
   2.3.2.4.
```
However, our target is in the form `cluster-service-name:port`, which fails validation in some server libraries, as highlighted by https://github.com/libressl/portable/issues/660 . We should instead just set `cluster-service-name` as an SNI.

## How
Remove port portion of the address before setting `ServerName` in the tunnel.

## Breaking Changes
None
