### PR TITLE
update icon to pull from helm http

### DIFF
--- a/helm/ingress-controller/Chart.yaml
+++ b/helm/ingress-controller/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
 home: https://ngrok.com
 sources:
   - https://github.com/ngrok/kubernetes-ingress-controller
-icon: https://ngrok.com/static/img/brand/ngrok-favicon.svg
+icon: https://ngrok.github.io/kubernetes-ingress-controller/ngrok-favicon.svg
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
## What

Fix the artifacthub.io icon for [ngrok/kubernetes-ingress-controller](https://artifacthub.io/packages/helm/ngrok/kubernetes-ingress-controller). This updates the chart, so artifacthub should also pick up the verification file change (https://github.com/ngrok/kubernetes-ingress-controller/pull/332).

## How

Updates icon to working link:
https://ngrok.github.io/kubernetes-ingress-controller/ngrok-favicon.svg

## Breaking Changes

None
