### PR TITLE
Update controller_bug_report.yaml to request k8s Logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
@@ -38,6 +38,15 @@ body:
     required: true
 - type: textarea
   attributes:
+    label: Kubernetes Logs
+    description: We want to see relevant kubernetes logs showing error messages
+or helpful debugging information
+    placeholder: >
+      Run `kubectl logs -l app.kubernetes.io/name=kubernetes-ingress-controller` and copy the output here.
+  validations:
+    required: true
+- type: textarea
+  attributes:
     label: Helm Chart configuration
     description: Additional description of your Helm Chart configuration.
     placeholder: >


### PR DESCRIPTION
Add a new field for them to paste relevant kubernetes logs into.

## What
*Describe what the change is solving*

We need people opening issue reports to include any relevant k8s logs

## Breaking Changes
*Are there any breaking changes in this PR?*

No.