### PR TITLE
fix: force controller recreation with checksum annotation when creden…

### DIFF
--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -28,6 +28,7 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: '8080'
         prometheus.io/scrape: 'true'
+        checksum/secret: {{ include (print $.Template.BasePath "/credentials-secret.yaml") . | sha256sum }}
       labels:
         {{- include "kubernetes-ingress-controller.selectorLabels" . | nindent 8 }}
         {{- if .Values.podLabels }}


### PR DESCRIPTION
## What

I met @stmcallister at Kubecon Europe 2024 (day before yesterday!) and tested the Ingress Controller, which I didn't know, about as soon as I got home, as I was already a fan of the local tunnel CLI.

While testing, I came across a small bug in the Helm chart.
When I first installed it, I'd made a mistake with the authToken (copy-pasting the id instead of the token itself), so I upgraded the release to fix it with the right authToken, but unfortunately the change took a long time to take effect because the pod controller wasn't recreated automatically.

#### How to reproduce :

```shell
$ helm install ngrok-ingress-controller ngrok/kubernetes-ingress-controller \
  --namespace ngrok-ingress-controller \
  --create-namespace \
  --set credentials.apiKey=$NGROK_API_KEY \
  --set credentials.authtoken=bad_token

$ kubectl logs -f -l 'app.kubernetes.io/component=controller' -n ngrok-ingress-controller
# => check the error message "The authtoken you specified does not look like a proper ngrok tunnel authtoken."

$ helm upgrade ngrok-ingress-controller ngrok/kubernetes-ingress-controller \
  --namespace ngrok-ingress-controller \
  --set credentials.apiKey=$NGROK_API_KEY \
  --set credentials.authtoken=$NGROK_AUTHTOKEN
# => the pod is not recreated, it will just end up being restarted after a few seconds or minutes by the kubelet because its healthcheck failed
```

#### Expected behavior :

```shell
$ helm install ngrok-ingress-controller ngrok/kubernetes-ingress-controller \
  --namespace ngrok-ingress-controller \
  --create-namespace \
  --set credentials.apiKey=$NGROK_API_KEY \
  --set credentials.authtoken=bad_token

$ kubectl logs -f -l 'app.kubernetes.io/component=controller' -n ngrok-ingress-controller
# => check the error message "The authtoken you specified does not look like a proper ngrok tunnel authtoken."

$ helm upgrade ngrok-ingress-controller ngrok/kubernetes-ingress-controller \
  --namespace ngrok-ingress-controller \
  --set credentials.apiKey=$NGROK_API_KEY \
  --set credentials.authtoken=$NGROK_AUTHTOKEN
# => the pod is recreated and the connection is instantly and successfully made
```

## How

I've just added an annotation to the `Pod` spec in the `Deployment`, with a checksum of the secret file that contains the `authToken`. This forces the creation of a new `ReplicaSet`, so that a new `Pod` is created, which then contains the most recent value of the `authToken`. 

I saw that you had already used a similar mechanism in the `Deployment` annotations, so I used the same syntax.

## Breaking Changes

No