### PR TITLE
fix(helm): move other checksums to pod annotations

### DIFF
--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -28,6 +28,8 @@ spec:
         prometheus.io/path: /metrics
         prometheus.io/port: '8080'
         prometheus.io/scrape: 'true'
+        checksum/controller-role: {{ include (print $.Template.BasePath "/rbac/role.yaml") . | sha256sum }}
+        checksum/rbac: {{ include (print $.Template.BasePath "/controller-rbac.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/credentials-secret.yaml") . | sha256sum }}
       labels:
         {{- include "kubernetes-ingress-controller.selectorLabels" . | nindent 8 }}

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -26,6 +26,8 @@ Should match all-options snapshot:
       template:
         metadata:
           annotations:
+            checksum/controller-role: 7e438ed756d7a0c59ca1d3df12a67d9466cc04bc91cf5abae742cc69f17f0342
+            checksum/rbac: d31fdcb337a6f1ee71323040c2cbc4d5580d73ae5f7623cd19be57db97f748c1
             checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
             prometheus.io/path: /metrics
             prometheus.io/port: "8080"
@@ -527,6 +529,8 @@ Should match default snapshot:
       template:
         metadata:
           annotations:
+            checksum/controller-role: 7e438ed756d7a0c59ca1d3df12a67d9466cc04bc91cf5abae742cc69f17f0342
+            checksum/rbac: d31fdcb337a6f1ee71323040c2cbc4d5580d73ae5f7623cd19be57db97f748c1
             checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
             prometheus.io/path: /metrics
             prometheus.io/port: "8080"


### PR DESCRIPTION
related: #353

## What

It came to light that these annotations should actually be on the pod rather than the deployment to force them to get recreated properly.

## Breaking Changes
None, leaving the deployment annotations in place for now - just duplicating them to the pod template.
