### PR TITLE
add gateway to client info comment

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -207,15 +207,12 @@ func runController(ctx context.Context, opts managerOpts) error {
 		os.Exit(1)
 	}
 
-	var comments []tunneldriver.TunnelDriverComments
+	var comments tunneldriver.TunnelDriverComments
 
 	if opts.useExperimentalGatewayAPI {
-		comments = append(
-			comments,
-			tunneldriver.TunnelDriverComments{
-				Gateway: "gateway-api",
-			},
-		)
+		comments = tunneldriver.TunnelDriverComments{
+			Gateway: "gateway-api",
+		}
 	}
 
 	td, err := tunneldriver.New(
@@ -223,7 +220,7 @@ func runController(ctx context.Context, opts managerOpts) error {
 			ServerAddr: opts.serverAddr,
 			Region:     opts.region,
 		},
-		comments,
+		&comments,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to create tunnel driver: %w", err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -211,11 +211,11 @@ func runController(ctx context.Context, opts managerOpts) error {
 
 	if opts.useExperimentalGatewayAPI {
 		comments = append(
-      comments,
-      tunneldriver.TunnelDriverComments{
-        Gateway: "gateway-api",
-      },
-    )
+			comments,
+			tunneldriver.TunnelDriverComments{
+				Gateway: "gateway-api",
+			},
+		)
 	}
 
 	td, err := tunneldriver.New(

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -207,10 +207,19 @@ func runController(ctx context.Context, opts managerOpts) error {
 		os.Exit(1)
 	}
 
-	td, err := tunneldriver.New(ctrl.Log.WithName("drivers").WithName("tunnel"), tunneldriver.TunnelDriverOpts{
-		ServerAddr: opts.serverAddr,
-		Region:     opts.region,
-	})
+	var comments []string
+
+	if opts.useExperimentalGatewayAPI {
+		comments = append(comments, "gateway-api")
+	}
+
+	td, err := tunneldriver.New(
+		ctrl.Log.WithName("drivers").WithName("tunnel"), tunneldriver.TunnelDriverOpts{
+			ServerAddr: opts.serverAddr,
+			Region:     opts.region,
+		},
+		comments...,
+	)
 	if err != nil {
 		return fmt.Errorf("unable to create tunnel driver: %w", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -207,10 +207,15 @@ func runController(ctx context.Context, opts managerOpts) error {
 		os.Exit(1)
 	}
 
-	var comments []string
+	var comments []tunneldriver.TunnelDriverComments
 
 	if opts.useExperimentalGatewayAPI {
-		comments = append(comments, "gateway-api")
+		comments = append(
+      comments,
+      tunneldriver.TunnelDriverComments{
+        Gateway: "gateway-api",
+      },
+    )
 	}
 
 	td, err := tunneldriver.New(
@@ -218,7 +223,7 @@ func runController(ctx context.Context, opts managerOpts) error {
 			ServerAddr: opts.serverAddr,
 			Region:     opts.region,
 		},
-		comments...,
+		comments,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to create tunnel driver: %w", err)

--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -53,9 +53,9 @@ type TunnelDriverOpts struct {
 }
 
 // New creates and initializes a new TunnelDriver
-func New(logger logr.Logger, opts TunnelDriverOpts) (*TunnelDriver, error) {
+func New(logger logr.Logger, opts TunnelDriverOpts, comments ...string) (*TunnelDriver, error) {
 	connOpts := []ngrok.ConnectOption{
-		ngrok.WithClientInfo("ngrok-ingress-controller", version.GetVersion()),
+		ngrok.WithClientInfo("ngrok-ingress-controller", version.GetVersion(), comments...),
 		ngrok.WithAuthtokenFromEnv(),
 		ngrok.WithLogger(k8sLogger{logger}),
 	}

--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -58,10 +58,10 @@ type TunnelDriverComments struct {
 }
 
 // New creates and initializes a new TunnelDriver
-func New(logger logr.Logger, opts TunnelDriverOpts, tunnelComments []TunnelDriverComments) (*TunnelDriver, error) {
+func New(logger logr.Logger, opts TunnelDriverOpts, tunnelComment *TunnelDriverComments) (*TunnelDriver, error) {
 	comments := []string{}
 
-	for _, tunnelComment := range tunnelComments {
+	if tunnelComment != nil {
 		commentJson, err := json.Marshal(tunnelComment)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## What
- Add `gateway-api` comment to client info

## How
- Add `gateway-api` comment if `useExperimentalGatewayAPI` is set
