### PR TITLE
helm: add apiURL option

### DIFF
--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -64,7 +64,8 @@ To uninstall the chart:
 | `credentials.apiKey`                 | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well. | `""`                                  |
 | `credentials.authtoken`              | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.  | `""`                                  |
 | `region`                             | ngrok region to create tunnels in. Defaults to connect to the closest geographical region.                            | `""`                                  |
-| `serverAddr`                         | This is the URL of the ngrok server to connect to. You should set this if you are using a custom ingress URL.         | `""`                                  |
+| `serverAddr`                         | This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address. | `""`                                  |
+| `apiURL`                             | This is the URL of the ngrok API. You should set this if you are using a custom API URL.                              | `""`                                  |
 | `metaData`                           | This is a map of key/value pairs that will be added as meta data to all ngrok api resources created                   | `{}`                                  |
 | `affinity`                           | Affinity for the controller pod assignment                                                                            | `{}`                                  |
 | `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                   | `""`                                  |

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -64,6 +64,9 @@ spec:
         {{- if .Values.region }}
         - --region={{ .Values.region}}
         {{- end }}
+        {{- if .Values.apiURL }}
+        - --api-url={{ .Values.apiURL}}
+        {{- end }}
         {{- if .Values.serverAddr }}
         - --server-addr={{ .Values.serverAddr}}
         {{- end }}

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -67,8 +67,11 @@ credentials:
 ## @param region ngrok region to create tunnels in. Defaults to connect to the closest geographical region.
 region: ""
 
-## @param serverAddr  This is the URL of the ngrok server to connect to. You should set this if you are using a custom ingress URL.
+## @param serverAddr  This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address.
 serverAddr: ""
+
+## @param apiURL  This is the URL of the ngrok API. You should set this if you are using a custom API URL.
+apiURL: ""
 
 ## @param metaData This is a map of key/value pairs that will be added as meta data to all ngrok api resources created
 metaData: {}


### PR DESCRIPTION
## What

Adds a helm value to set the API URL as an alternative to the `NGROK_API_URL` environment variable.

## How

* Boring helm plumbing
* Keep the default from the environment, but override it if the helm value is set

## Breaking Changes

None, since no one should have this helm value set. Existing users can continue with the env var and switch to the helm value at their leisure.
