### PR TITLE
root-cas setting

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,7 +99,7 @@ type managerOpts struct {
 
 	region string
 
-	hostCA bool
+	rootCAs string
 }
 
 func cmd() *cobra.Command {
@@ -122,7 +122,7 @@ func cmd() *cobra.Command {
 	c.Flags().StringVar(&opts.watchNamespace, "watch-namespace", "", "Namespace to watch for Kubernetes resources. Defaults to all namespaces.")
 	c.Flags().StringVar(&opts.managerName, "manager-name", "ngrok-ingress-controller-manager", "Manager name to identify unique ngrok ingress controller instances")
 	c.Flags().BoolVar(&opts.useExperimentalGatewayAPI, "use-experimental-gateway-api", false, "sets up experemental gatewayAPI")
-	c.Flags().BoolVar(&opts.hostCA, "host-ca", false, "use the host's default CA store for the ngrok agent connection")
+	c.Flags().StringVar(&opts.rootCAs, "root-cas", "internal", "internal (default) or host: use the internalt ngrok agent CA or the host CA")
 	opts.zapOpts = &zap.Options{}
 	goFlagSet := flag.NewFlagSet("manager", flag.ContinueOnError)
 	opts.zapOpts.BindFlags(goFlagSet)
@@ -231,7 +231,7 @@ func runController(ctx context.Context, opts managerOpts) error {
 		tunneldriver.TunnelDriverOpts{
 			ServerAddr: opts.serverAddr,
 			Region:     opts.region,
-			HostCA:     opts.hostCA,
+			RootCAs:    opts.rootCAs,
 			Comments:   &comments,
 		},
 	)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -227,14 +227,21 @@ func runController(ctx context.Context, opts managerOpts) error {
 		}
 	}
 
+	rootCAs := "internal"
+
+	if opts.rootCAs != "" {
+		rootCAs = opts.rootCAs
+	}
+
 	td, err := tunneldriver.New(ctx, ctrl.Log.WithName("drivers").WithName("tunnel"),
 		tunneldriver.TunnelDriverOpts{
 			ServerAddr: opts.serverAddr,
 			Region:     opts.region,
-			RootCAs:    opts.rootCAs,
+			RootCAs:    rootCAs,
 			Comments:   &comments,
 		},
 	)
+
 	if err != nil {
 		return fmt.Errorf("unable to create tunnel driver: %w", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,6 +98,8 @@ type managerOpts struct {
 	ngrokAPIKey string
 
 	region string
+
+	hostCA bool
 }
 
 func cmd() *cobra.Command {
@@ -120,6 +122,7 @@ func cmd() *cobra.Command {
 	c.Flags().StringVar(&opts.watchNamespace, "watch-namespace", "", "Namespace to watch for Kubernetes resources. Defaults to all namespaces.")
 	c.Flags().StringVar(&opts.managerName, "manager-name", "ngrok-ingress-controller-manager", "Manager name to identify unique ngrok ingress controller instances")
 	c.Flags().BoolVar(&opts.useExperimentalGatewayAPI, "use-experimental-gateway-api", false, "sets up experemental gatewayAPI")
+	c.Flags().BoolVar(&opts.hostCA, "host-ca", false, "use the host's default CA store for the ngrok agent connection")
 	opts.zapOpts = &zap.Options{}
 	goFlagSet := flag.NewFlagSet("manager", flag.ContinueOnError)
 	opts.zapOpts.BindFlags(goFlagSet)
@@ -228,8 +231,9 @@ func runController(ctx context.Context, opts managerOpts) error {
 		tunneldriver.TunnelDriverOpts{
 			ServerAddr: opts.serverAddr,
 			Region:     opts.region,
+			HostCA:     opts.hostCA,
+			Comments:   &comments,
 		},
-		&comments,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to create tunnel driver: %w", err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,7 +122,7 @@ func cmd() *cobra.Command {
 	c.Flags().StringVar(&opts.watchNamespace, "watch-namespace", "", "Namespace to watch for Kubernetes resources. Defaults to all namespaces.")
 	c.Flags().StringVar(&opts.managerName, "manager-name", "ngrok-ingress-controller-manager", "Manager name to identify unique ngrok ingress controller instances")
 	c.Flags().BoolVar(&opts.useExperimentalGatewayAPI, "use-experimental-gateway-api", false, "sets up experemental gatewayAPI")
-	c.Flags().StringVar(&opts.rootCAs, "root-cas", "internal", "internal (default) or host: use the internalt ngrok agent CA or the host CA")
+	c.Flags().StringVar(&opts.rootCAs, "root-cas", "trusted", "trusted (default) or host: use the trusted ngrok agent CA or the host CA")
 	opts.zapOpts = &zap.Options{}
 	goFlagSet := flag.NewFlagSet("manager", flag.ContinueOnError)
 	opts.zapOpts.BindFlags(goFlagSet)
@@ -227,7 +227,7 @@ func runController(ctx context.Context, opts managerOpts) error {
 		}
 	}
 
-	rootCAs := "internal"
+	rootCAs := "trusted"
 
 	if opts.rootCAs != "" {
 		rootCAs = opts.rootCAs

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -64,7 +64,7 @@ To uninstall the chart:
 | `credentials.apiKey`                 | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well.     | `""`                                  |
 | `credentials.authtoken`              | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.      | `""`                                  |
 | `region`                             | ngrok region to create tunnels in. Defaults to connect to the closest geographical region.                                | `""`                                  |
-| `hostCA`                             | Whether to use the host's default CA store when making the ngrok agent connection. Uses the internal ngrok CA by default. | `false`                               |
+| `rootCAs`                            | Whether to use the internal (default) CA store or the host CA when making the ngrok agent connection.                     | `internal`                            |
 | `serverAddr`                         | This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address.     | `""`                                  |
 | `apiURL`                             | This is the URL of the ngrok API. You should set this if you are using a custom API URL.                                  | `""`                                  |
 | `metaData`                           | This is a map of key/value pairs that will be added as meta data to all ngrok api resources created                       | `{}`                                  |

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -45,49 +45,49 @@ To uninstall the chart:
 
 ### Controller parameters
 
-| Name                                 | Description                                                                                                               | Value                                 |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `podAnnotations`                     | Used to apply custom annotations to the ingress pods.                                                                     | `{}`                                  |
-| `podLabels`                          | Used to apply custom labels to the ingress pods.                                                                          | `{}`                                  |
-| `replicaCount`                       | The number of controllers to run.                                                                                         | `1`                                   |
-| `image.registry`                     | The ngrok ingress controller image registry.                                                                              | `docker.io`                           |
-| `image.repository`                   | The ngrok ingress controller image repository.                                                                            | `ngrok/kubernetes-ingress-controller` |
-| `image.tag`                          | The ngrok ingress controller image tag. Defaults to the chart's appVersion if not specified                               | `""`                                  |
-| `image.pullPolicy`                   | The ngrok ingress controller image pull policy.                                                                           | `IfNotPresent`                        |
-| `image.pullSecrets`                  | An array of imagePullSecrets to be used when pulling the image.                                                           | `[]`                                  |
-| `ingressClass.name`                  | The name of the ingress class to use.                                                                                     | `ngrok`                               |
-| `ingressClass.create`                | Whether to create the ingress class.                                                                                      | `true`                                |
-| `ingressClass.default`               | Whether to set the ingress class as default.                                                                              | `false`                               |
-| `controllerName`                     | The name of the controller to look for matching ingress classes                                                           | `k8s.ngrok.com/ingress-controller`    |
-| `watchNamespace`                     | The namespace to watch for ingress resources. Defaults to all                                                             | `""`                                  |
-| `credentials.secret.name`            | The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.        | `""`                                  |
-| `credentials.apiKey`                 | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well.     | `""`                                  |
-| `credentials.authtoken`              | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.      | `""`                                  |
-| `region`                             | ngrok region to create tunnels in. Defaults to connect to the closest geographical region.                                | `""`                                  |
-| `rootCAs`                            | Whether to use the internal (default) CA store or the host CA when making the ngrok agent connection.                     | `internal`                            |
-| `serverAddr`                         | This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address.     | `""`                                  |
-| `apiURL`                             | This is the URL of the ngrok API. You should set this if you are using a custom API URL.                                  | `""`                                  |
-| `metaData`                           | This is a map of key/value pairs that will be added as meta data to all ngrok api resources created                       | `{}`                                  |
-| `affinity`                           | Affinity for the controller pod assignment                                                                                | `{}`                                  |
-| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                       | `""`                                  |
-| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                  | `soft`                                |
-| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `""`                                  |
-| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                                                    | `""`                                  |
-| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                                                 | `[]`                                  |
-| `priorityClassName`                  | Priority class for pod scheduling                                                                                         | `""`                                  |
-| `podDisruptionBudget.create`         | Enable a Pod Disruption Budget creation                                                                                   | `false`                               |
-| `podDisruptionBudget.minAvailable`   | Minimum number/percentage of pods that should remain scheduled                                                            | `""`                                  |
-| `podDisruptionBudget.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable                                                            | `1`                                   |
-| `resources.limits`                   | The resources limits for the container                                                                                    | `{}`                                  |
-| `resources.requests`                 | The requested resources for the container                                                                                 | `{}`                                  |
-| `extraVolumes`                       | An array of extra volumes to add to the controller.                                                                       | `[]`                                  |
-| `extraVolumeMounts`                  | An array of extra volume mounts to add to the controller.                                                                 | `[]`                                  |
-| `extraEnv`                           | an object of extra environment variables to add to the controller.                                                        | `{}`                                  |
-| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                                                      | `true`                                |
-| `serviceAccount.name`                | The name of the ServiceAccount to use.                                                                                    | `""`                                  |
-| `serviceAccount.annotations`         | Additional annotations to add to the ServiceAccount                                                                       | `{}`                                  |
-| `log.level`                          | The level to log at. One of 'debug', 'info', or 'error'.                                                                  | `info`                                |
-| `log.stacktraceLevel`                | The level to report stacktrace logs one of 'info' or 'error'.                                                             | `error`                               |
-| `log.format`                         | The log format to use. One of console, json.                                                                              | `json`                                |
-| `lifecycle`                          | an object containing lifecycle configuration                                                                              | `{}`                                  |
+| Name                                 | Description                                                                                                           | Value                                 |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `podAnnotations`                     | Used to apply custom annotations to the ingress pods.                                                                 | `{}`                                  |
+| `podLabels`                          | Used to apply custom labels to the ingress pods.                                                                      | `{}`                                  |
+| `replicaCount`                       | The number of controllers to run.                                                                                     | `1`                                   |
+| `image.registry`                     | The ngrok ingress controller image registry.                                                                          | `docker.io`                           |
+| `image.repository`                   | The ngrok ingress controller image repository.                                                                        | `ngrok/kubernetes-ingress-controller` |
+| `image.tag`                          | The ngrok ingress controller image tag. Defaults to the chart's appVersion if not specified                           | `""`                                  |
+| `image.pullPolicy`                   | The ngrok ingress controller image pull policy.                                                                       | `IfNotPresent`                        |
+| `image.pullSecrets`                  | An array of imagePullSecrets to be used when pulling the image.                                                       | `[]`                                  |
+| `ingressClass.name`                  | The name of the ingress class to use.                                                                                 | `ngrok`                               |
+| `ingressClass.create`                | Whether to create the ingress class.                                                                                  | `true`                                |
+| `ingressClass.default`               | Whether to set the ingress class as default.                                                                          | `false`                               |
+| `controllerName`                     | The name of the controller to look for matching ingress classes                                                       | `k8s.ngrok.com/ingress-controller`    |
+| `watchNamespace`                     | The namespace to watch for ingress resources. Defaults to all                                                         | `""`                                  |
+| `credentials.secret.name`            | The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.    | `""`                                  |
+| `credentials.apiKey`                 | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well. | `""`                                  |
+| `credentials.authtoken`              | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.  | `""`                                  |
+| `region`                             | ngrok region to create tunnels in. Defaults to connect to the closest geographical region.                            | `""`                                  |
+| `rootCAs`                            | Whether to use the internal (default) or host's CAs for the controller.                                               | `""`                                  |
+| `serverAddr`                         | This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address. | `""`                                  |
+| `apiURL`                             | This is the URL of the ngrok API. You should set this if you are using a custom API URL.                              | `""`                                  |
+| `metaData`                           | This is a map of key/value pairs that will be added as meta data to all ngrok api resources created                   | `{}`                                  |
+| `affinity`                           | Affinity for the controller pod assignment                                                                            | `{}`                                  |
+| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                   | `""`                                  |
+| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `soft`                                |
+| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                                  |
+| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                                                | `""`                                  |
+| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                                             | `[]`                                  |
+| `priorityClassName`                  | Priority class for pod scheduling                                                                                     | `""`                                  |
+| `podDisruptionBudget.create`         | Enable a Pod Disruption Budget creation                                                                               | `false`                               |
+| `podDisruptionBudget.minAvailable`   | Minimum number/percentage of pods that should remain scheduled                                                        | `""`                                  |
+| `podDisruptionBudget.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable                                                        | `1`                                   |
+| `resources.limits`                   | The resources limits for the container                                                                                | `{}`                                  |
+| `resources.requests`                 | The requested resources for the container                                                                             | `{}`                                  |
+| `extraVolumes`                       | An array of extra volumes to add to the controller.                                                                   | `[]`                                  |
+| `extraVolumeMounts`                  | An array of extra volume mounts to add to the controller.                                                             | `[]`                                  |
+| `extraEnv`                           | an object of extra environment variables to add to the controller.                                                    | `{}`                                  |
+| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                                                  | `true`                                |
+| `serviceAccount.name`                | The name of the ServiceAccount to use.                                                                                | `""`                                  |
+| `serviceAccount.annotations`         | Additional annotations to add to the ServiceAccount                                                                   | `{}`                                  |
+| `log.level`                          | The level to log at. One of 'debug', 'info', or 'error'.                                                              | `info`                                |
+| `log.stacktraceLevel`                | The level to report stacktrace logs one of 'info' or 'error'.                                                         | `error`                               |
+| `log.format`                         | The log format to use. One of console, json.                                                                          | `json`                                |
+| `lifecycle`                          | an object containing lifecycle configuration                                                                          | `{}`                                  |
 

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -45,48 +45,49 @@ To uninstall the chart:
 
 ### Controller parameters
 
-| Name                                 | Description                                                                                                           | Value                                 |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `podAnnotations`                     | Used to apply custom annotations to the ingress pods.                                                                 | `{}`                                  |
-| `podLabels`                          | Used to apply custom labels to the ingress pods.                                                                      | `{}`                                  |
-| `replicaCount`                       | The number of controllers to run.                                                                                     | `1`                                   |
-| `image.registry`                     | The ngrok ingress controller image registry.                                                                          | `docker.io`                           |
-| `image.repository`                   | The ngrok ingress controller image repository.                                                                        | `ngrok/kubernetes-ingress-controller` |
-| `image.tag`                          | The ngrok ingress controller image tag. Defaults to the chart's appVersion if not specified                           | `""`                                  |
-| `image.pullPolicy`                   | The ngrok ingress controller image pull policy.                                                                       | `IfNotPresent`                        |
-| `image.pullSecrets`                  | An array of imagePullSecrets to be used when pulling the image.                                                       | `[]`                                  |
-| `ingressClass.name`                  | The name of the ingress class to use.                                                                                 | `ngrok`                               |
-| `ingressClass.create`                | Whether to create the ingress class.                                                                                  | `true`                                |
-| `ingressClass.default`               | Whether to set the ingress class as default.                                                                          | `false`                               |
-| `controllerName`                     | The name of the controller to look for matching ingress classes                                                       | `k8s.ngrok.com/ingress-controller`    |
-| `watchNamespace`                     | The namespace to watch for ingress resources. Defaults to all                                                         | `""`                                  |
-| `credentials.secret.name`            | The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.    | `""`                                  |
-| `credentials.apiKey`                 | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well. | `""`                                  |
-| `credentials.authtoken`              | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.  | `""`                                  |
-| `region`                             | ngrok region to create tunnels in. Defaults to connect to the closest geographical region.                            | `""`                                  |
-| `serverAddr`                         | This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address. | `""`                                  |
-| `apiURL`                             | This is the URL of the ngrok API. You should set this if you are using a custom API URL.                              | `""`                                  |
-| `metaData`                           | This is a map of key/value pairs that will be added as meta data to all ngrok api resources created                   | `{}`                                  |
-| `affinity`                           | Affinity for the controller pod assignment                                                                            | `{}`                                  |
-| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                   | `""`                                  |
-| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `soft`                                |
-| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                                  |
-| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                                                | `""`                                  |
-| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                                             | `[]`                                  |
-| `priorityClassName`                  | Priority class for pod scheduling                                                                                     | `""`                                  |
-| `podDisruptionBudget.create`         | Enable a Pod Disruption Budget creation                                                                               | `false`                               |
-| `podDisruptionBudget.minAvailable`   | Minimum number/percentage of pods that should remain scheduled                                                        | `""`                                  |
-| `podDisruptionBudget.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable                                                        | `1`                                   |
-| `resources.limits`                   | The resources limits for the container                                                                                | `{}`                                  |
-| `resources.requests`                 | The requested resources for the container                                                                             | `{}`                                  |
-| `extraVolumes`                       | An array of extra volumes to add to the controller.                                                                   | `[]`                                  |
-| `extraVolumeMounts`                  | An array of extra volume mounts to add to the controller.                                                             | `[]`                                  |
-| `extraEnv`                           | an object of extra environment variables to add to the controller.                                                    | `{}`                                  |
-| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                                                  | `true`                                |
-| `serviceAccount.name`                | The name of the ServiceAccount to use.                                                                                | `""`                                  |
-| `serviceAccount.annotations`         | Additional annotations to add to the ServiceAccount                                                                   | `{}`                                  |
-| `log.level`                          | The level to log at. One of 'debug', 'info', or 'error'.                                                              | `info`                                |
-| `log.stacktraceLevel`                | The level to report stacktrace logs one of 'info' or 'error'.                                                         | `error`                               |
-| `log.format`                         | The log format to use. One of console, json.                                                                          | `json`                                |
-| `lifecycle`                          | an object containing lifecycle configuration                                                                          | `{}`                                  |
+| Name                                 | Description                                                                                                               | Value                                 |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `podAnnotations`                     | Used to apply custom annotations to the ingress pods.                                                                     | `{}`                                  |
+| `podLabels`                          | Used to apply custom labels to the ingress pods.                                                                          | `{}`                                  |
+| `replicaCount`                       | The number of controllers to run.                                                                                         | `1`                                   |
+| `image.registry`                     | The ngrok ingress controller image registry.                                                                              | `docker.io`                           |
+| `image.repository`                   | The ngrok ingress controller image repository.                                                                            | `ngrok/kubernetes-ingress-controller` |
+| `image.tag`                          | The ngrok ingress controller image tag. Defaults to the chart's appVersion if not specified                               | `""`                                  |
+| `image.pullPolicy`                   | The ngrok ingress controller image pull policy.                                                                           | `IfNotPresent`                        |
+| `image.pullSecrets`                  | An array of imagePullSecrets to be used when pulling the image.                                                           | `[]`                                  |
+| `ingressClass.name`                  | The name of the ingress class to use.                                                                                     | `ngrok`                               |
+| `ingressClass.create`                | Whether to create the ingress class.                                                                                      | `true`                                |
+| `ingressClass.default`               | Whether to set the ingress class as default.                                                                              | `false`                               |
+| `controllerName`                     | The name of the controller to look for matching ingress classes                                                           | `k8s.ngrok.com/ingress-controller`    |
+| `watchNamespace`                     | The namespace to watch for ingress resources. Defaults to all                                                             | `""`                                  |
+| `credentials.secret.name`            | The name of the secret the credentials are in. If not provided, one will be generated using the helm release name.        | `""`                                  |
+| `credentials.apiKey`                 | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well.     | `""`                                  |
+| `credentials.authtoken`              | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.      | `""`                                  |
+| `region`                             | ngrok region to create tunnels in. Defaults to connect to the closest geographical region.                                | `""`                                  |
+| `hostCA`                             | Whether to use the host's default CA store when making the ngrok agent connection. Uses the internal ngrok CA by default. | `false`                               |
+| `serverAddr`                         | This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address.     | `""`                                  |
+| `apiURL`                             | This is the URL of the ngrok API. You should set this if you are using a custom API URL.                                  | `""`                                  |
+| `metaData`                           | This is a map of key/value pairs that will be added as meta data to all ngrok api resources created                       | `{}`                                  |
+| `affinity`                           | Affinity for the controller pod assignment                                                                                | `{}`                                  |
+| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                       | `""`                                  |
+| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                  | `soft`                                |
+| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `""`                                  |
+| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                                                    | `""`                                  |
+| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                                                 | `[]`                                  |
+| `priorityClassName`                  | Priority class for pod scheduling                                                                                         | `""`                                  |
+| `podDisruptionBudget.create`         | Enable a Pod Disruption Budget creation                                                                                   | `false`                               |
+| `podDisruptionBudget.minAvailable`   | Minimum number/percentage of pods that should remain scheduled                                                            | `""`                                  |
+| `podDisruptionBudget.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable                                                            | `1`                                   |
+| `resources.limits`                   | The resources limits for the container                                                                                    | `{}`                                  |
+| `resources.requests`                 | The requested resources for the container                                                                                 | `{}`                                  |
+| `extraVolumes`                       | An array of extra volumes to add to the controller.                                                                       | `[]`                                  |
+| `extraVolumeMounts`                  | An array of extra volume mounts to add to the controller.                                                                 | `[]`                                  |
+| `extraEnv`                           | an object of extra environment variables to add to the controller.                                                        | `{}`                                  |
+| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                                                      | `true`                                |
+| `serviceAccount.name`                | The name of the ServiceAccount to use.                                                                                    | `""`                                  |
+| `serviceAccount.annotations`         | Additional annotations to add to the ServiceAccount                                                                       | `{}`                                  |
+| `log.level`                          | The level to log at. One of 'debug', 'info', or 'error'.                                                                  | `info`                                |
+| `log.stacktraceLevel`                | The level to report stacktrace logs one of 'info' or 'error'.                                                             | `error`                               |
+| `log.format`                         | The log format to use. One of console, json.                                                                              | `json`                                |
+| `lifecycle`                          | an object containing lifecycle configuration                                                                              | `{}`                                  |
 

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -64,7 +64,7 @@ To uninstall the chart:
 | `credentials.apiKey`                 | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well. | `""`                                  |
 | `credentials.authtoken`              | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.  | `""`                                  |
 | `region`                             | ngrok region to create tunnels in. Defaults to connect to the closest geographical region.                            | `""`                                  |
-| `rootCAs`                            | Whether to use the internal (default) or host's CAs for the controller.                                               | `""`                                  |
+| `rootCAs`                            | Set to `trusted` for the default behavior or `host` to use the host's CAs for the controller.                         | `""`                                  |
 | `serverAddr`                         | This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address. | `""`                                  |
 | `apiURL`                             | This is the URL of the ngrok API. You should set this if you are using a custom API URL.                              | `""`                                  |
 | `metaData`                           | This is a map of key/value pairs that will be added as meta data to all ngrok api resources created                   | `{}`                                  |

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -64,7 +64,7 @@ To uninstall the chart:
 | `credentials.apiKey`                 | Your ngrok API key. If provided, it will be will be written to the secret and the authtoken must be provided as well. | `""`                                  |
 | `credentials.authtoken`              | Your ngrok authtoken. If provided, it will be will be written to the secret and the apiKey must be provided as well.  | `""`                                  |
 | `region`                             | ngrok region to create tunnels in. Defaults to connect to the closest geographical region.                            | `""`                                  |
-| `rootCAs`                            | Set to `trusted` for the default behavior or `host` to use the host's CAs for the controller.                         | `""`                                  |
+| `rootCAs`                            | Set to "trusted" for the ngrok agent CA or "host" to trust the host's CA. Defaults to "trusted".                      | `""`                                  |
 | `serverAddr`                         | This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address. | `""`                                  |
 | `apiURL`                             | This is the URL of the ngrok API. You should set this if you are using a custom API URL.                              | `""`                                  |
 | `metaData`                           | This is a map of key/value pairs that will be added as meta data to all ngrok api resources created                   | `{}`                                  |

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -67,8 +67,8 @@ spec:
         {{- if .Values.apiURL }}
         - --api-url={{ .Values.apiURL}}
         {{- end }}
-        {{- if .Values.hostCA }}
-        - --host-ca
+        {{- if .Values.rootCAs }}
+        - --root-cas={{ .Values.rootCAs}}
         {{- end }}
         {{- if .Values.serverAddr }}
         - --server-addr={{ .Values.serverAddr}}

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -67,6 +67,9 @@ spec:
         {{- if .Values.apiURL }}
         - --api-url={{ .Values.apiURL}}
         {{- end }}
+        {{- if .Values.hostCA }}
+        - --host-ca
+        {{- end }}
         {{- if .Values.serverAddr }}
         - --server-addr={{ .Values.serverAddr}}
         {{- end }}

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -67,8 +67,8 @@ credentials:
 ## @param region ngrok region to create tunnels in. Defaults to connect to the closest geographical region.
 region: ""
 
-## @param hostCA Whether to use the host's default CA store when making the ngrok agent connection. Uses the internal ngrok CA by default.
-hostCA: false
+## @param rootCAs Whether to use the internal (default) or host's CAs for the controller.
+rootCAs: ""
 
 ## @param serverAddr  This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address.
 serverAddr: ""

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -67,7 +67,7 @@ credentials:
 ## @param region ngrok region to create tunnels in. Defaults to connect to the closest geographical region.
 region: ""
 
-## @param rootCAs Whether to use the internal (default) or host's CAs for the controller.
+## @param rootCAs Set to "trusted" for the ngrok agent CA or "host" to trust the host's CA. Defaults to "trusted".
 rootCAs: ""
 
 ## @param serverAddr  This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address.

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -67,6 +67,9 @@ credentials:
 ## @param region ngrok region to create tunnels in. Defaults to connect to the closest geographical region.
 region: ""
 
+## @param hostCA Whether to use the host's default CA store when making the ngrok agent connection. Uses the internal ngrok CA by default.
+hostCA: false
+
 ## @param serverAddr  This is the address of the ngrok server to connect to. You should set this if you are using a custom ingress address.
 serverAddr: ""
 

--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -101,6 +101,12 @@ func New(ctx context.Context, logger logr.Logger, opts TunnelDriverOpts) (*Tunne
 	}
 
 	isHostCA := opts.RootCAs == "host"
+
+	// validate is default "internal" or "host
+	if !isHostCA && opts.RootCAs != "internal" {
+		return nil, fmt.Errorf("invalid value for RootCAs: %s", opts.RootCAs)
+	}
+
 	// Configure certs if the custom cert directory exists or host if set
 	if _, err := os.Stat(customCertsPath); !os.IsNotExist(err) || isHostCA {
 		caCerts, err := caCerts(isHostCA)

--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -102,8 +102,8 @@ func New(ctx context.Context, logger logr.Logger, opts TunnelDriverOpts) (*Tunne
 
 	isHostCA := opts.RootCAs == "host"
 
-	// validate is default "internal" or "host
-	if !isHostCA && opts.RootCAs != "internal" {
+	// validate is "trusted",  "" or "host
+	if !isHostCA && opts.RootCAs != "trusted" && opts.RootCAs != "" {
 		return nil, fmt.Errorf("invalid value for RootCAs: %s", opts.RootCAs)
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #369 

## What
Utilizes the `trusted` or `host` CA as the source of truth via a helm install flag.

## How
Takes an install option for `--set rootCAs=host`  and plumb the `isHostCA` check into the `caCerts` for it to just get the host certs. 

## Verification

- Build 2048 image, copying in cert and updating certs, apply changes
- Set `--set rootCAs host` and make deploy, no controller errors ✅ and can play example
- Set `--set rootCAs host` with canonical 2048 example without cert gives errors in controller
- Set `--set rootCAs trusted` no errors and plays 2048 as expected
- no set plays as expected 

