### PR TITLE
fix: panics in oauth providers

### DIFF
--- a/api/ingress/v1alpha1/ngrok_common.go
+++ b/api/ingress/v1alpha1/ngrok_common.go
@@ -273,6 +273,10 @@ type EndpointOAuthGitHub struct {
 	Organizations []string `json:"organizations,omitempty"`
 }
 
+func (github *EndpointOAuthGitHub) Provided() bool {
+	return github != nil
+}
+
 func (github *EndpointOAuthGitHub) ToNgrok(clientSecret *string) *ngrok.EndpointOAuth {
 	if github == nil {
 		return nil
@@ -295,6 +299,10 @@ type EndpointOAuthFacebook struct {
 	OAuthProviderCommon `json:",inline"`
 }
 
+func (facebook *EndpointOAuthFacebook) Provided() bool {
+	return facebook != nil
+}
+
 func (facebook *EndpointOAuthFacebook) ToNgrok(clientSecret *string) *ngrok.EndpointOAuth {
 	if facebook == nil {
 		return nil
@@ -313,6 +321,10 @@ func (facebook *EndpointOAuthFacebook) ToNgrok(clientSecret *string) *ngrok.Endp
 
 type EndpointOAuthMicrosoft struct {
 	OAuthProviderCommon `json:",inline"`
+}
+
+func (microsoft *EndpointOAuthMicrosoft) Provided() bool {
+	return microsoft != nil
 }
 
 func (microsoft *EndpointOAuthMicrosoft) ToNgrok(clientSecret *string) *ngrok.EndpointOAuth {
@@ -335,6 +347,10 @@ type EndpointOAuthGoogle struct {
 	OAuthProviderCommon `json:",inline"`
 }
 
+func (google *EndpointOAuthGoogle) Provided() bool {
+	return google != nil
+}
+
 func (google *EndpointOAuthGoogle) ToNgrok(clientSecret *string) *ngrok.EndpointOAuth {
 	if google == nil {
 		return nil
@@ -353,6 +369,10 @@ func (google *EndpointOAuthGoogle) ToNgrok(clientSecret *string) *ngrok.Endpoint
 
 type EndpointOAuthLinkedIn struct {
 	OAuthProviderCommon `json:",inline"`
+}
+
+func (linkedin *EndpointOAuthLinkedIn) Provided() bool {
+	return linkedin != nil
 }
 
 func (linkedin *EndpointOAuthLinkedIn) ToNgrok(clientSecret *string) *ngrok.EndpointOAuth {
@@ -375,6 +395,10 @@ type EndpointOAuthGitLab struct {
 	OAuthProviderCommon `json:",inline"`
 }
 
+func (gitlab *EndpointOAuthGitLab) Provided() bool {
+	return gitlab != nil
+}
+
 func (gitlab *EndpointOAuthGitLab) ToNgrok(clientSecret *string) *ngrok.EndpointOAuth {
 	if gitlab == nil {
 		return nil
@@ -395,6 +419,10 @@ type EndpointOAuthTwitch struct {
 	OAuthProviderCommon `json:",inline"`
 }
 
+func (twitch *EndpointOAuthTwitch) Provided() bool {
+	return twitch != nil
+}
+
 func (twitch *EndpointOAuthTwitch) ToNgrok(clientSecret *string) *ngrok.EndpointOAuth {
 	if twitch == nil {
 		return nil
@@ -413,6 +441,10 @@ func (twitch *EndpointOAuthTwitch) ToNgrok(clientSecret *string) *ngrok.Endpoint
 
 type EndpointOAuthAmazon struct {
 	OAuthProviderCommon `json:",inline"`
+}
+
+func (amazon *EndpointOAuthAmazon) Provided() bool {
+	return amazon != nil
 }
 
 func (amazon *EndpointOAuthAmazon) ToNgrok(clientSecret *string) *ngrok.EndpointOAuth {

--- a/api/ingress/v1alpha1/ngrok_common_test.go
+++ b/api/ingress/v1alpha1/ngrok_common_test.go
@@ -1,0 +1,45 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+type oauthProvider interface {
+	Provided() bool
+}
+
+func TestOAuthCommonProvided(t *testing.T) {
+	oauth := EndpointOAuth{}
+
+	providers := []oauthProvider{
+		oauth.Amazon,
+		oauth.Facebook,
+		oauth.Github,
+		oauth.Gitlab,
+		oauth.Google,
+		oauth.Linkedin,
+		oauth.Microsoft,
+		oauth.Twitch,
+	}
+
+	// When no provider config is present, all should return false for Provided()
+	for _, p := range providers {
+		assert.False(t, p.Provided())
+	}
+
+	microsoft := &EndpointOAuthMicrosoft{}
+	microsoft.ClientID = ptr.To("a")
+
+	oauth = EndpointOAuth{
+		Microsoft: microsoft,
+	}
+	// When a provider is present, it should return true for Provided() and ones
+	// that are not provided should return false.
+	assert.True(t, oauth.Microsoft.Provided())
+	assert.False(t, oauth.Google.Provided())
+	assert.False(t, oauth.Twitch.Provided())
+	assert.False(t, oauth.Github.Provided())
+}

--- a/internal/controller/ingress/httpsedge_controller.go
+++ b/internal/controller/ingress/httpsedge_controller.go
@@ -769,7 +769,7 @@ func (u *edgeRouteModuleUpdater) setEdgeRouteOAuth(ctx context.Context, route *n
 	}
 
 	for _, p := range providers {
-		if p == nil {
+		if !p.Provided() {
 			continue
 		}
 
@@ -954,6 +954,8 @@ func (u *edgeRouteModuleUpdater) getSecret(ctx context.Context, secretRef ingres
 
 type OAuthProvider interface {
 	ClientSecretKeyRef() *ingressv1alpha1.SecretKeyRef
+	// Provided returns true if configuration was supplied for the provider
+	Provided() bool
 	ToNgrok(*string) *ngrok.EndpointOAuth
 }
 


### PR DESCRIPTION
## What

FIxes an underlying bug when configuring oAuth providers that caused panics. Checking an interface for `nil` checks if it is nil, and not the underlying data.

## How

Add `Provided() bool` to the `OauthProvider` interface that checks if it was provided and fix the nil check.

## Breaking Changes

No