### PR TITLE
Add GatewayClass to cachestore

### DIFF
--- a/internal/store/cachestores.go
+++ b/internal/store/cachestores.go
@@ -37,8 +37,9 @@ type CacheStores struct {
 	ServiceV1      cache.Store
 
 	// Gateway API Stores
-	Gateway   cache.Store
-	HTTPRoute cache.Store
+	Gateway      cache.Store
+	GatewayClass cache.Store
+	HTTPRoute    cache.Store
 
 	// Ngrok Stores
 	DomainV1             cache.Store
@@ -59,8 +60,9 @@ func NewCacheStores(logger logr.Logger) CacheStores {
 		IngressClassV1: cache.NewStore(clusterResourceKeyFunc),
 		ServiceV1:      cache.NewStore(keyFunc),
 		// Gateway API Stores
-		Gateway:   cache.NewStore(keyFunc),
-		HTTPRoute: cache.NewStore(keyFunc),
+		Gateway:      cache.NewStore(keyFunc),
+		GatewayClass: cache.NewStore(keyFunc),
+		HTTPRoute:    cache.NewStore(keyFunc),
 		// Ngrok Stores
 		DomainV1:             cache.NewStore(keyFunc),
 		TunnelV1:             cache.NewStore(keyFunc),
@@ -112,6 +114,8 @@ func (c CacheStores) Get(obj runtime.Object) (item interface{}, exists bool, err
 		return c.HTTPRoute.Get(obj)
 	case *gatewayv1.Gateway:
 		return c.Gateway.Get(obj)
+	case *gatewayv1.GatewayClass:
+		return c.GatewayClass.Get(obj)
 
 	// ----------------------------------------------------------------------------
 	// Ngrok API Support
@@ -155,6 +159,8 @@ func (c CacheStores) Add(obj runtime.Object) error {
 		return c.HTTPRoute.Add(obj)
 	case *gatewayv1.Gateway:
 		return c.Gateway.Add(obj)
+	case *gatewayv1.GatewayClass:
+		return c.GatewayClass.Add(obj)
 
 	// ----------------------------------------------------------------------------
 	// Ngrok API Support
@@ -199,6 +205,8 @@ func (c CacheStores) Delete(obj runtime.Object) error {
 		return c.HTTPRoute.Delete(obj)
 	case *gatewayv1.Gateway:
 		return c.Gateway.Delete(obj)
+	case *gatewayv1.GatewayClass:
+		return c.GatewayClass.Delete(obj)
 
 	// ----------------------------------------------------------------------------
 	// Ngrok API Support

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -752,6 +752,7 @@ func (d *Driver) calculateHTTPSEdges(ingressDomains *[]ingressv1alpha1.Domain, g
 				gatewayDomains[string(*listener.Hostname)] = string(*listener.Hostname)
 			}
 			if len(gatewayDomains) == 0 {
+				d.log.Info("no usable domains in gateway, may be missing https listener", "gateway", gtw.Name)
 				continue
 			}
 			for _, httproute := range httproutes {


### PR DESCRIPTION
Resolves:

> 2024-05-16T17:41:30Z	ERROR	cache-store-driver	error updating object in create	{"UpdateStoreHandlerFor": "", "object": {"name": "simple-gatewayclass"}, "error": "unsupported object type: *v1.GatewayClass"}

Also logs when a gateway does not have an https listener (so cannot be used).