### PR TITLE
refactor: annotations parsers to handle client.Object instead of just networking.Ingress

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ngrok/kubernetes-ingress-controller/internal/errors"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DeniedKeyName name of the key that contains the reason to deny a location
@@ -44,12 +45,12 @@ type RouteModules struct {
 }
 
 type Extractor struct {
-	annotations map[string]parser.IngressAnnotation
+	annotations map[string]parser.Annotation
 }
 
 func NewAnnotationsExtractor() Extractor {
 	return Extractor{
-		annotations: map[string]parser.IngressAnnotation{
+		annotations: map[string]parser.Annotation{
 			"Compression":         compression.NewParser(),
 			"Headers":             headers.NewParser(),
 			"IPRestriction":       ip_policies.NewParser(),
@@ -102,14 +103,14 @@ func (e Extractor) Extract(ing *networking.Ingress) *RouteModules {
 
 // Extracts a list of module set names from the annotation
 // k8s.ngrok.com/modules: "module1,module2"
-func ExtractNgrokModuleSetsFromAnnotations(ing *networking.Ingress) ([]string, error) {
-	return parser.GetStringSliceAnnotation("modules", ing)
+func ExtractNgrokModuleSetsFromAnnotations(obj client.Object) ([]string, error) {
+	return parser.GetStringSliceAnnotation("modules", obj)
 }
 
 // Extracts a single traffic policy str from the annotation
 // k8s.ngrok.com/traffic-policy: "module1"
-func ExtractNgrokTrafficPolicyFromAnnotations(ing *networking.Ingress) (string, error) {
-	policies, err := parser.GetStringSliceAnnotation("traffic-policy", ing)
+func ExtractNgrokTrafficPolicyFromAnnotations(obj client.Object) (string, error) {
+	policies, err := parser.GetStringSliceAnnotation("traffic-policy", obj)
 
 	if err != nil {
 		return "", err

--- a/internal/annotations/compression/compression.go
+++ b/internal/annotations/compression/compression.go
@@ -3,20 +3,20 @@ package compression
 import (
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/ingress/v1alpha1"
 	"github.com/ngrok/kubernetes-ingress-controller/internal/annotations/parser"
-	networking "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type compression struct{}
 
-func NewParser() parser.IngressAnnotation {
+func NewParser() parser.Annotation {
 	return compression{}
 }
 
 // Parse parses the annotations contained in the ingress and returns a
 // compression configuration or an error. If no compression annotations are
 // found, the returned error an errors.ErrMissingAnnotations.
-func (c compression) Parse(ing *networking.Ingress) (interface{}, error) {
-	v, err := parser.GetBoolAnnotation("https-compression", ing)
+func (c compression) Parse(obj client.Object) (interface{}, error) {
+	v, err := parser.GetBoolAnnotation("https-compression", obj)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/annotations/headers/headers.go
+++ b/internal/annotations/headers/headers.go
@@ -4,7 +4,7 @@ import (
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/ingress/v1alpha1"
 	"github.com/ngrok/kubernetes-ingress-controller/internal/annotations/parser"
 	"github.com/ngrok/kubernetes-ingress-controller/internal/errors"
-	networking "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type EndpointHeaders = ingressv1alpha1.EndpointHeaders
@@ -13,14 +13,14 @@ type EndpointResponseHeaders = ingressv1alpha1.EndpointResponseHeaders
 
 type headers struct{}
 
-func NewParser() parser.IngressAnnotation {
+func NewParser() parser.Annotation {
 	return headers{}
 }
 
-func (h headers) Parse(ing *networking.Ingress) (interface{}, error) {
+func (h headers) Parse(obj client.Object) (interface{}, error) {
 	parsed := &EndpointHeaders{}
 
-	v, err := parser.GetStringSliceAnnotation("request-headers-remove", ing)
+	v, err := parser.GetStringSliceAnnotation("request-headers-remove", obj)
 	if err != nil {
 		if !errors.IsMissingAnnotations(err) {
 			return parsed, err
@@ -34,7 +34,7 @@ func (h headers) Parse(ing *networking.Ingress) (interface{}, error) {
 		parsed.Request.Remove = v
 	}
 
-	m, err := parser.GetStringMapAnnotation("request-headers-add", ing)
+	m, err := parser.GetStringMapAnnotation("request-headers-add", obj)
 	if err != nil {
 		if !errors.IsMissingAnnotations(err) {
 			return parsed, err
@@ -54,7 +54,7 @@ func (h headers) Parse(ing *networking.Ingress) (interface{}, error) {
 		}
 	}
 
-	v, err = parser.GetStringSliceAnnotation("response-headers-remove", ing)
+	v, err = parser.GetStringSliceAnnotation("response-headers-remove", obj)
 	if err != nil {
 		if !errors.IsMissingAnnotations(err) {
 			return parsed, err
@@ -68,7 +68,7 @@ func (h headers) Parse(ing *networking.Ingress) (interface{}, error) {
 		parsed.Response.Remove = v
 	}
 
-	m, err = parser.GetStringMapAnnotation("response-headers-add", ing)
+	m, err = parser.GetStringMapAnnotation("response-headers-add", obj)
 	if err != nil {
 		if !errors.IsMissingAnnotations(err) {
 			return parsed, err

--- a/internal/annotations/ip_policies/ip_policy.go
+++ b/internal/annotations/ip_policies/ip_policy.go
@@ -3,17 +3,17 @@ package ip_policies
 import (
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/ingress/v1alpha1"
 	"github.com/ngrok/kubernetes-ingress-controller/internal/annotations/parser"
-	networking "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ipPolicy struct{}
 
-func NewParser() parser.IngressAnnotation {
+func NewParser() parser.Annotation {
 	return ipPolicy{}
 }
 
-func (p ipPolicy) Parse(ing *networking.Ingress) (interface{}, error) {
-	v, err := parser.GetStringSliceAnnotation("ip-policies", ing)
+func (p ipPolicy) Parse(obj client.Object) (interface{}, error) {
+	v, err := parser.GetStringSliceAnnotation("ip-policies", obj)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/annotations/tls/tls.go
+++ b/internal/annotations/tls/tls.go
@@ -3,22 +3,22 @@ package tls
 import (
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/ingress/v1alpha1"
 	"github.com/ngrok/kubernetes-ingress-controller/internal/annotations/parser"
-	networking "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type EndpointTLSTerminationAtEdge = ingressv1alpha1.EndpointTLSTerminationAtEdge
 
 type tls struct{}
 
-func NewParser() parser.IngressAnnotation {
+func NewParser() parser.Annotation {
 	return tls{}
 }
 
 // Parse parses the annotations contained in the ingress and returns a
 // tls configuration or an error. If no tls annotations are
 // found, the returned error an errors.ErrMissingAnnotations.
-func (t tls) Parse(ing *networking.Ingress) (interface{}, error) {
-	v, err := parser.GetStringAnnotation("tls-min-version", ing)
+func (t tls) Parse(obj client.Object) (interface{}, error) {
+	v, err := parser.GetStringAnnotation("tls-min-version", obj)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/annotations/webhook_verification/webhook_verification.go
+++ b/internal/annotations/webhook_verification/webhook_verification.go
@@ -3,7 +3,7 @@ package webhook_verification
 import (
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/ingress/v1alpha1"
 	"github.com/ngrok/kubernetes-ingress-controller/internal/annotations/parser"
-	networking "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type EndpointWebhookVerification = ingressv1alpha1.EndpointWebhookVerification
@@ -11,12 +11,12 @@ type SecretKeyRef = ingressv1alpha1.SecretKeyRef
 
 type webhookVerification struct{}
 
-func NewParser() parser.IngressAnnotation {
+func NewParser() parser.Annotation {
 	return webhookVerification{}
 }
 
-func (wv webhookVerification) Parse(ing *networking.Ingress) (interface{}, error) {
-	provider, err := parser.GetStringAnnotation("webhook-verification-provider", ing)
+func (wv webhookVerification) Parse(obj client.Object) (interface{}, error) {
+	provider, err := parser.GetStringAnnotation("webhook-verification-provider", obj)
 	if err != nil {
 		return nil, err
 	}
@@ -26,12 +26,12 @@ func (wv webhookVerification) Parse(ing *networking.Ingress) (interface{}, error
 		return &EndpointWebhookVerification{Provider: provider}, nil
 	}
 
-	secretName, err := parser.GetStringAnnotation("webhook-verification-secret-name", ing)
+	secretName, err := parser.GetStringAnnotation("webhook-verification-secret-name", obj)
 	if err != nil {
 		return nil, err
 	}
 
-	secretKey, err := parser.GetStringAnnotation("webhook-verification-secret-key", ing)
+	secretKey, err := parser.GetStringAnnotation("webhook-verification-secret-key", obj)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What

The annotations parser currently expects an ingress of type *networking.Ingress. We can make this more flexible for our use case and allow it to parse annotations from any `client.Object`. We'll want this shortly for being able to extract annotations from services for example in #375 

## How

`*networking.Ingress` implements client.Object so all of our changes are just in the `internal/annotations` package.
 
## Breaking Changes
No
