### PR TITLE
chore: Turn on golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,7 +133,10 @@ jobs:
     - name: Build
       run: make build
 
-    - name: Test and Lint
+    - name: Lint
+      run: make lint
+
+    - name: Test
       run: make test
 
     - name: Build the Docker image

--- a/internal/controller/ingress/ippolicy_controller.go
+++ b/internal/controller/ingress/ippolicy_controller.go
@@ -31,7 +31,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -131,8 +131,8 @@ func (r *IPPolicyReconciler) update(ctx context.Context, policy *ingressv1alpha1
 		r.Recorder.Event(policy, v1.EventTypeNormal, "Updating", fmt.Sprintf("Updating IPPolicy %s", policy.Name))
 		_, err := r.IPPoliciesClient.Update(ctx, &ngrok.IPPolicyUpdate{
 			ID:          policy.Status.ID,
-			Description: pointer.String(policy.Spec.Description),
-			Metadata:    pointer.String(policy.Spec.Metadata),
+			Description: ptr.To(policy.Spec.Description),
+			Metadata:    ptr.To(policy.Spec.Metadata),
 		})
 		if err != nil {
 			return err
@@ -357,7 +357,7 @@ func (d *IPPolicyDiff) createRule(rule ingressv1alpha1.IPPolicyRule) *ngrok.IPPo
 	return &ngrok.IPPolicyRuleCreate{
 		IPPolicyID:  d.policyID,
 		CIDR:        rule.CIDR,
-		Action:      pointer.String(rule.Action),
+		Action:      ptr.To(rule.Action),
 		Metadata:    rule.Metadata,
 		Description: rule.Description,
 	}
@@ -373,8 +373,8 @@ func (d *IPPolicyDiff) addUpdateIfNeeded(rule ingressv1alpha1.IPPolicyRule, remo
 
 	d.updates = append(d.updates, &ngrok.IPPolicyRuleUpdate{
 		ID:          remoteRule.ID,
-		Metadata:    pointer.String(rule.Metadata),
-		Description: pointer.String(rule.Description),
-		CIDR:        pointer.String(rule.CIDR),
+		Metadata:    ptr.To(rule.Metadata),
+		Description: ptr.To(rule.Description),
+		CIDR:        ptr.To(rule.CIDR),
 	})
 }

--- a/internal/controller/ingress/ippolicy_controllers_test.go
+++ b/internal/controller/ingress/ippolicy_controllers_test.go
@@ -6,7 +6,7 @@ import (
 	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/ingress/v1alpha1"
 	"github.com/ngrok/ngrok-api-go/v5"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestIPPolicyDiff(t *testing.T) {
@@ -34,7 +34,7 @@ func TestIPPolicyDiff(t *testing.T) {
 	assert.Empty(t, diff.NeedsDelete())
 	assert.Empty(t, diff.NeedsUpdate())
 	assert.Equal(t, []*ngrok.IPPolicyRuleCreate{
-		{IPPolicyID: "test", CIDR: specRules[2].CIDR, Action: pointer.String(IPPolicyRuleActionDeny)}},
+		{IPPolicyID: "test", CIDR: specRules[2].CIDR, Action: ptr.To(IPPolicyRuleActionDeny)}},
 		diff.NeedsCreate(),
 	)
 
@@ -42,21 +42,21 @@ func TestIPPolicyDiff(t *testing.T) {
 	assert.Empty(t, diff.NeedsUpdate())
 	assert.Equal(t, []*ngrok.IPPolicyRule{remoteRules[0]}, diff.NeedsDelete())
 	assert.Equal(t, []*ngrok.IPPolicyRuleCreate{
-		{IPPolicyID: "test", CIDR: specRules[0].CIDR, Action: pointer.String(IPPolicyRuleActionDeny)},
+		{IPPolicyID: "test", CIDR: specRules[0].CIDR, Action: ptr.To(IPPolicyRuleActionDeny)},
 	}, diff.NeedsCreate())
 
 	assert.True(t, diff.Next())
 	assert.Empty(t, diff.NeedsUpdate())
 	assert.Equal(t, []*ngrok.IPPolicyRule{remoteRules[1]}, diff.NeedsDelete())
 	assert.Equal(t, []*ngrok.IPPolicyRuleCreate{
-		{IPPolicyID: "test", CIDR: specRules[1].CIDR, Action: pointer.String(IPPolicyRuleActionAllow)},
+		{IPPolicyID: "test", CIDR: specRules[1].CIDR, Action: ptr.To(IPPolicyRuleActionAllow)},
 	}, diff.NeedsCreate())
 
 	assert.True(t, diff.Next())
 	assert.Empty(t, diff.NeedsUpdate())
 	assert.Equal(t, []*ngrok.IPPolicyRule{}, diff.NeedsDelete())
 	assert.Equal(t, []*ngrok.IPPolicyRuleCreate{
-		{IPPolicyID: "test", CIDR: specRules[3].CIDR, Action: pointer.String(IPPolicyRuleActionAllow)},
+		{IPPolicyID: "test", CIDR: specRules[3].CIDR, Action: ptr.To(IPPolicyRuleActionAllow)},
 	}, diff.NeedsCreate())
 
 	assert.True(t, diff.Next())
@@ -68,7 +68,7 @@ func TestIPPolicyDiff(t *testing.T) {
 	assert.Empty(t, diff.NeedsDelete())
 	assert.Empty(t, diff.NeedsCreate())
 	assert.Equal(t, []*ngrok.IPPolicyRuleUpdate{
-		{ID: "5", CIDR: pointer.String("172.19.0.0/16"), Description: pointer.String("b"), Metadata: pointer.String("")},
+		{ID: "5", CIDR: ptr.To("172.19.0.0/16"), Description: ptr.To("b"), Metadata: ptr.To("")},
 	}, diff.NeedsUpdate())
 
 	assert.False(t, diff.Next())

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -98,7 +98,7 @@ func NewErrInvalidIngressSpec() ErrInvalidIngressSpec {
 }
 
 // AddError adds an error to the list of errors
-func (e ErrInvalidIngressSpec) AddError(err string) {
+func (e *ErrInvalidIngressSpec) AddError(err string) {
 	e.errors = append(e.errors, err)
 }
 

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,16 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddErrorToNewInvalidIngressSpec(t *testing.T) {
+	err := NewErrInvalidIngressSpec()
+	err.AddError("error1")
+	err.AddError("error2")
+
+	assert.True(t, err.HasErrors())
+	assert.Len(t, err.errors, 2)
+}

--- a/internal/store/driver_test.go
+++ b/internal/store/driver_test.go
@@ -380,9 +380,9 @@ var _ = Describe("Driver", func() {
 					},
 				},
 			}
-			driver.store.Add(ms1)
-			driver.store.Add(ms2)
-			driver.store.Add(ms3)
+			Expect(driver.store.Add(ms1)).To(BeNil())
+			Expect(driver.store.Add(ms2)).To(BeNil())
+			Expect(driver.store.Add(ms3)).To(BeNil())
 		})
 
 		It("Should return an empty module set if the ingress has no modules annotaion", func() {
@@ -445,7 +445,7 @@ var _ = Describe("Driver", func() {
 					Policy: []byte(`{"inbound": [{"name":"t","actions":[{"type":"deny"}]}], "outbound": []}`),
 				},
 			}
-			driver.store.Add(policyCrd)
+			Expect(driver.store.Add(policyCrd)).To(BeNil())
 		})
 
 		It("Should return an empty policy if the rule has nothing in it", func() {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -418,18 +418,18 @@ func (s Store) shouldHandleIngressCheckClass(ing *netv1.Ingress) (bool, error) {
 func (s Store) shouldHandleIngressIsValid(ing *netv1.Ingress) (bool, error) {
 	errs := errors.NewErrInvalidIngressSpec()
 	if len(ing.Spec.Rules) > 1 {
-		errs.AddError(fmt.Sprintf("A maximum of one rule is required to be set"))
+		errs.AddError("A maximum of one rule is required to be set")
 	}
 	if len(ing.Spec.Rules) == 0 {
-		errs.AddError(fmt.Sprintf("At least one rule is required to be set"))
+		errs.AddError("At least one rule is required to be set")
 	} else {
 		if ing.Spec.Rules[0].Host == "" {
-			errs.AddError(fmt.Sprintf("A host is required to be set"))
+			errs.AddError("A host is required to be set")
 		}
 
 		for _, path := range ing.Spec.Rules[0].HTTP.Paths {
 			if path.Backend.Resource != nil {
-				errs.AddError(fmt.Sprintf("Resource backends are not supported"))
+				errs.AddError("Resource backends are not supported")
 			}
 		}
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Store", func() {
 		Context("when the ingress class exists", func() {
 			BeforeEach(func() {
 				ic := NewTestIngressClass(ngrokIngressClass, true, true)
-				store.Add(&ic)
+				Expect(store.Add(&ic)).To(BeNil())
 			})
 			It("returns the ingress class", func() {
 				ic, err := store.GetIngressClassV1(ngrokIngressClass)
@@ -54,7 +54,7 @@ var _ = Describe("Store", func() {
 		Context("when the ingress exists", func() {
 			BeforeEach(func() {
 				ing := NewTestIngressV1("test-ingress", "test-namespace")
-				store.Add(&ing)
+				Expect(store.Add(&ing)).To(BeNil())
 			})
 			It("returns the ingress", func() {
 				ing, err := store.GetIngressV1("test-ingress", "test-namespace")
@@ -75,7 +75,7 @@ var _ = Describe("Store", func() {
 		Context("when the service exists", func() {
 			BeforeEach(func() {
 				svc := NewTestServiceV1("test-service", "test-namespace")
-				store.Add(&svc)
+				Expect(store.Add(&svc)).To(BeNil())
 			})
 			It("returns the service", func() {
 				svc, err := store.GetServiceV1("test-service", "test-namespace")
@@ -96,9 +96,9 @@ var _ = Describe("Store", func() {
 		Context("when the ngrok ingress exists", func() {
 			BeforeEach(func() {
 				ing := NewTestIngressV1WithClass("test-ingress", "test-namespace", ngrokIngressClass)
-				store.Add(&ing)
+				Expect(store.Add(&ing)).To(BeNil())
 				ic := NewTestIngressClass(ngrokIngressClass, true, true)
-				store.Add(&ic)
+				Expect(store.Add(&ic)).To(BeNil())
 			})
 			It("returns the ngrok ingress", func() {
 				ing, err := store.GetNgrokIngressV1("test-ingress", "test-namespace")
@@ -107,7 +107,7 @@ var _ = Describe("Store", func() {
 			})
 			It("Filters out ingresses that don't match the ngrok ingress class", func() {
 				ingNotNgrok := NewTestIngressV1WithClass("ingNotNgrok", "test-namespace", "not-ngrok")
-				store.Add(&ingNotNgrok)
+				Expect(store.Add(&ingNotNgrok)).To(BeNil())
 
 				ing, err := store.GetNgrokIngressV1("ingNotNgrok", "test-namespace")
 				Expect(err).To(HaveOccurred())
@@ -115,7 +115,7 @@ var _ = Describe("Store", func() {
 			})
 			It("Filters finds ones without a class if we are default", func() {
 				ingNoClass := NewTestIngressV1("ingNoClass", "test-namespace")
-				store.Add(&ingNoClass)
+				Expect(store.Add(&ingNoClass)).To(BeNil())
 
 				ing, err := store.GetNgrokIngressV1("ingNoClass", "test-namespace")
 				Expect(err).ToNot(HaveOccurred())
@@ -135,11 +135,11 @@ var _ = Describe("Store", func() {
 		Context("when there are ngrok ingress classes", func() {
 			BeforeEach(func() {
 				ic1 := NewTestIngressClass("ngrok1", true, true)
-				store.Add(&ic1)
+				Expect(store.Add(&ic1)).To(BeNil())
 				ic2 := NewTestIngressClass("ngrok2", true, true)
-				store.Add(&ic2)
+				Expect(store.Add(&ic2)).To(BeNil())
 				ic3 := NewTestIngressClass("different", true, false)
-				store.Add(&ic3)
+				Expect(store.Add(&ic3)).To(BeNil())
 			})
 			It("returns the ngrok ingress classes and doesn't return the different one", func() {
 				ics := store.ListNgrokIngressClassesV1()
@@ -164,11 +164,11 @@ var _ = Describe("Store", func() {
 			iMatching := NewTestIngressV1WithClass("test1", "test", "ngrok")
 			iNotMatching := NewTestIngressV1WithClass("test2", "test", "test")
 			iNoClass := NewTestIngressV1("test3", "test")
-			store.Add(&iMatching)
-			store.Add(&iNotMatching)
-			store.Add(&iNoClass)
+			Expect(store.Add(&iMatching)).To(BeNil())
+			Expect(store.Add(&iNotMatching)).To(BeNil())
+			Expect(store.Add(&iNoClass)).To(BeNil())
 			for _, ic := range ingressClasses {
-				store.Add(&ic)
+				Expect(store.Add(&ic)).To(BeNil())
 			}
 			ings := store.ListNgrokIngressesV1()
 			Expect(len(ings)).To(Equal(expectedMatchingIngressesCount))
@@ -189,11 +189,11 @@ var _ = Describe("Store", func() {
 		Context("when there are NgrokModuleSets", func() {
 			BeforeEach(func() {
 				m1 := NewTestNgrokModuleSet("ngrok", "test", true)
-				store.Add(&m1)
+				Expect(store.Add(&m1)).To(BeNil())
 				m2 := NewTestNgrokModuleSet("ngrok", "test2", true)
-				store.Add(&m2)
+				Expect(store.Add(&m2)).To(BeNil())
 				m3 := NewTestNgrokModuleSet("test", "test", true)
-				store.Add(&m3)
+				Expect(store.Add(&m3)).To(BeNil())
 			})
 			It("returns the NgrokModuleSet", func() {
 				modules := store.ListNgrokModuleSetsV1()
@@ -212,7 +212,7 @@ var _ = Describe("Store", func() {
 		Context("when the NgrokModuleSet exists", func() {
 			BeforeEach(func() {
 				m := NewTestNgrokModuleSet("ngrok", "test", true)
-				store.Add(&m)
+				Expect(store.Add(&m)).To(BeNil())
 			})
 			It("returns the NgrokModuleSet", func() {
 				modset, err := store.GetNgrokModuleSetV1("ngrok", "test")
@@ -234,7 +234,7 @@ var _ = Describe("Store", func() {
 		Context("when the NgrokTrafficPolicy exists", func() {
 			BeforeEach(func() {
 				tp := NewTestNgrokTrafficPolicy("ngrok", "test", "{\"inbound\": \"you know this can be anything though\"}")
-				store.Add(&tp)
+				Expect(store.Add(&tp)).To(BeNil())
 			})
 			It("returns the NgrokTrafficPolicy", func() {
 				tp, err := store.GetNgrokTrafficPolicyV1("ngrok", "test")

--- a/pkg/tunneldriver/driver.go
+++ b/pkg/tunneldriver/driver.go
@@ -179,6 +179,7 @@ func New(ctx context.Context, logger logr.Logger, opts TunnelDriverOpts) (*Tunne
 			}
 		}),
 	)
+	//nolint:errcheck
 	go ngrok.Connect(ctx, connOpts...)
 
 	return td, nil


### PR DESCRIPTION
## What

We updated our `Makefile` with a `lint` target. This fixes the issues that are included in the default linters so that we can turn it on for CI to continually check that our code is being linted.

## How
Fix linter warnings & add tests for places where it caught issues.

## Breaking Changes
No