### PR TITLE
feat: Support TLS termination in modulesets for Load Balancer Services

### DIFF
--- a/api/ingress/v1alpha1/ngrokmoduleset_types.go
+++ b/api/ingress/v1alpha1/ngrokmoduleset_types.go
@@ -46,7 +46,7 @@ type NgrokModuleSetModules struct {
 	// SAML configuration for this module set
 	SAML *EndpointSAML `json:"saml,omitempty"`
 	// TLSTermination configuration for this module set
-	TLSTermination *EndpointTLSTerminationAtEdge `json:"tlsTermination,omitempty"`
+	TLSTermination *EndpointTLSTermination `json:"tlsTermination,omitempty"`
 	// MutualTLS configuration for this module set
 	MutualTLS *EndpointMutualTLS `json:"mutualTLS,omitempty"`
 	// WebhookVerification configuration for this module set

--- a/api/ingress/v1alpha1/zz_generated.deepcopy.go
+++ b/api/ingress/v1alpha1/zz_generated.deepcopy.go
@@ -1103,8 +1103,8 @@ func (in *NgrokModuleSetModules) DeepCopyInto(out *NgrokModuleSetModules) {
 	}
 	if in.TLSTermination != nil {
 		in, out := &in.TLSTermination, &out.TLSTermination
-		*out = new(EndpointTLSTerminationAtEdge)
-		**out = **in
+		*out = new(EndpointTLSTermination)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.MutualTLS != nil {
 		in, out := &in.MutualTLS, &out.MutualTLS

--- a/helm/ingress-controller/templates/crds/ingress.k8s.ngrok.com_ngrokmodulesets.yaml
+++ b/helm/ingress-controller/templates/crds/ingress.k8s.ngrok.com_ngrokmodulesets.yaml
@@ -970,6 +970,13 @@ spec:
                     description: MinVersion is the minimum TLS version to allow for
                       connections to the edge
                     type: string
+                  terminateAt:
+                    description: |-
+                      TerminateAt determines where the TLS connection should be terminated.
+                      "edge" if the ngrok edge should terminate TLS traffic, "upstream" if TLS
+                      traffic should be passed through to the upstream ngrok agent /
+                      application server for termination.
+                    type: string
                 type: object
               webhookVerification:
                 description: WebhookVerification configuration for this module set

--- a/internal/controller/ingress/service_controller.go
+++ b/internal/controller/ingress/service_controller.go
@@ -317,6 +317,7 @@ func (r *ServiceReconciler) buildTunnelAndEdge(ctx context.Context, svc *corev1.
 		if moduleSets != nil {
 			edge.Spec.IPRestriction = moduleSets.Modules.IPRestriction
 			edge.Spec.MutualTLS = moduleSets.Modules.MutualTLS
+			edge.Spec.TLSTermination = moduleSets.Modules.TLSTermination
 		}
 		if policy != nil {
 			edge.Spec.Policy = policy.Spec.Policy

--- a/internal/store/driver.go
+++ b/internal/store/driver.go
@@ -16,6 +16,7 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -832,8 +833,10 @@ func (d *Driver) calculateHTTPSEdgesFromIngress(edgeMap map[string]ingressv1alph
 				continue
 			}
 
-			if modSet.Modules.TLSTermination != nil {
-				edge.Spec.TLSTermination = modSet.Modules.TLSTermination
+			if modSet.Modules.TLSTermination != nil && modSet.Modules.TLSTermination.MinVersion != nil {
+				edge.Spec.TLSTermination = &ingressv1alpha1.EndpointTLSTerminationAtEdge{
+					MinVersion: ptr.Deref(modSet.Modules.TLSTermination.MinVersion, ""),
+				}
 			}
 
 			if modSet.Modules.MutualTLS != nil {


### PR DESCRIPTION
## What

This allows users to specify termination behavior in a moduleset and then use it in the `k8s.ngrok.com/modules` annotation to terminate TLS at either the edge or the upstrem.

## How

Since `EndpointTLSTermination` is a superset of `EndpointTLSTerminationAtEdge`, use the former in the moduleset so that it can be used when building both TLS & HTTPS Edges. When building the TLS configuration for HTTPSEdges created by the Ingress Controller, we have to convert `EndpointTLSTermination` to `EndpointTLSTerminationAtEdge` now.

## Breaking Changes

No