### PR TITLE
fix: Controller bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
@@ -39,8 +39,7 @@ body:
 - type: textarea
   attributes:
     label: Kubernetes Logs
-    description: We want to see relevant kubernetes logs showing error messages
-or helpful debugging information
+    description: We want to see relevant kubernetes logs showing error messages or helpful debugging information
     placeholder: >
       Run `kubectl logs -l app.kubernetes.io/name=kubernetes-ingress-controller` and copy the output here.
   validations:

--- a/helm/ingress-controller/Chart.lock
+++ b/helm/ingress-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.19.3
-digest: sha256:b0c5b947a6622accb48678c6034a1180e1fb58d0d8c8d2fa44cb7e9c3b1a4255
-generated: "2024-05-21T13:06:30.412702362-05:00"
+  version: 2.20.3
+digest: sha256:993c3981678605068ef47b75614bcc0bcb70570962337b9e03e3ebc588ca1729
+generated: "2024-07-09T11:39:09.193679089-05:00"


### PR DESCRIPTION
## What

Fixes the controller bug report issue template. Currently it is not being shown due to an issue with the yaml

![image](https://github.com/ngrok/kubernetes-ingress-controller/assets/6900888/f3b7b45f-dc7e-4c14-b941-2a27077c5a92)

## How

Move it onto a single line.

## Breaking Changes
No
