### PR TITLE
chore: Disable helm dependency auto-updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ endef
 _helm_setup:
 	./scripts/helm-setup.sh
 	helm repo add bitnami https://charts.bitnami.com/bitnami
-	helm dependency update $(HELM_CHART_DIR)
+	helm dependency build $(HELM_CHART_DIR)
 
 .PHONY: helm-lint
 helm-lint: _helm_setup ## Lint the helm chart


### PR DESCRIPTION
## What

These were causing more changes to get pulled in when a new chart was published. We are fine with having a slightly outdated library chart in exchange for it not changing out from under us

## How

Just run `helm dependency build` instead of `helm dependency update`.

## Breaking Changes

No