### PR TITLE
refactor: Easier to read driver seed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/ngrok/kubernetes-ingress-controller
 
-go 1.21
-
-toolchain go1.21.5
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/internal/store/driver_test.go
+++ b/internal/store/driver_test.go
@@ -500,7 +500,6 @@ var _ = Describe("Driver", func() {
 
 			jsonString, err := json.Marshal(policy)
 			Expect(err).To(BeNil())
-			println("policy", string(jsonString))
 
 			Expect(len(policy.Inbound) == 3).To(BeTrue())
 			Expect(len(policy.Outbound)).To(BeZero())

--- a/internal/util/k8s.go
+++ b/internal/util/k8s.go
@@ -1,0 +1,17 @@
+package util
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+// ToClientObjects converts a slice of objects whose pointer implements client.Object
+// to a slice of client.Objects
+func ToClientObjects[T any, PT interface {
+	*T
+	client.Object
+}](s []T) []client.Object {
+	objs := make([]client.Object, len(s))
+	for i, obj := range s {
+		var p PT = &obj
+		objs[i] = p
+	}
+	return objs
+}

--- a/internal/util/k8s_test.go
+++ b/internal/util/k8s_test.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"testing"
+
+	ingressv1alpha1 "github.com/ngrok/kubernetes-ingress-controller/api/ingress/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestToClientObjects(t *testing.T) {
+	s := []ingressv1alpha1.Domain{}
+	assert.Empty(t, ToClientObjects(s))
+
+	s = []ingressv1alpha1.Domain{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: ingressv1alpha1.DomainSpec{
+				Domain: "test.ngrok.io",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test2",
+				Namespace: "other",
+			},
+			Spec: ingressv1alpha1.DomainSpec{
+				Domain: "test.ngrok.io",
+			},
+		},
+	}
+
+	objs := ToClientObjects(s)
+	assert.Len(t, objs, 2)
+
+	// Test some client.Object methods on our objects
+	assert.Equal(t, "test", objs[0].GetName())
+	assert.Equal(t, "default", objs[0].GetNamespace())
+	assert.Equal(t, "test2", objs[1].GetName())
+	assert.Equal(t, "other", objs[1].GetNamespace())
+
+	assert.Equal(t, &s[0], objs[0])
+	assert.Equal(t, &s[1], objs[1])
+}


### PR DESCRIPTION
## What

There are a some places where I think we can use generics and other methods to make the code easier to read, maintain, and test. The initial seed was one of those places that can benefit from this. I think we can also re-use the new `internal/util` package in more places too.

## How

* Adds a generic function which can takes `[]T`, where `*T` implements `client.Object`, and returns `[]client.Object` 
* Adds a function that can fetch all items of a particular type and return them as `[]client.Object`
* refactors the driver Seed so we can easily see all the types we are seeding

This is slightly less memory efficient as rather than getting a pointer for each item before we call the store to update it, we pre-compute a slice with all pointers. This seemed like an acceptable trade-off for making the code easier to read and manage.

## Breaking Changes
No