### PR TITLE
fix(store): Multiple ingress rules per ingress not working

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -417,9 +417,6 @@ func (s Store) shouldHandleIngressCheckClass(ing *netv1.Ingress) (bool, error) {
 // shouldHandleIngressIsValid checks if the ingress should be handled by the controller based on the ingress spec
 func (s Store) shouldHandleIngressIsValid(ing *netv1.Ingress) (bool, error) {
 	errs := errors.NewErrInvalidIngressSpec()
-	if len(ing.Spec.Rules) > 1 {
-		errs.AddError("A maximum of one rule is required to be set")
-	}
 	if len(ing.Spec.Rules) == 0 {
 		errs.AddError("At least one rule is required to be set")
 	} else {


### PR DESCRIPTION
Was originally supposed to be completed in https://github.com/ngrok/kubernetes-ingress-controller/issues/56, but might have been a slight regression

## What

Adds support for having multiple rules per ingress. Example:
```yaml
kind: Ingress
apiVersion: networking.k8s.io/v1
metadata:
  name: test-ingress
  namespace: default
  annotations:
    k8s.ngrok.com/modules: "compression,tls,only-trusted-ips,circuit-breaker"
spec:
  ingressClassName: ngrok
  rules:
  - host: my-test-app-4.ngrok.io
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: test-app-1
            port:
              name: http
  - host: my-test-app-5.ngrok.io
    http:
      paths:
      - path: /app-2
        pathType: Prefix
        backend:
          service:
            name: test-app-2
            port:
              name: http
      - path: /app-1
        pathType: Prefix
        backend:
          service:
            name: test-app-1
            port:
              name: http
```

## How

* We had a check that marked ingresses with multiple rules as an error. Remove that check
* Add a test that checks that when we list ngrok ingresses in the store that we get back ones with more than 1 ingress rule.

## Breaking Changes
No
